### PR TITLE
Fix AI demo when speed is zero

### DIFF
--- a/js/cubeout.js
+++ b/js/cubeout.js
@@ -1713,6 +1713,9 @@ function play_game(canvas, ctx, start_handler) {
   refresh_column();
 
   GAME_SPEED = SPEED;
+  if (DEMO_MODE && GAME_SPEED === 0) {
+    GAME_SPEED = 1;
+  }
   BLOCKS_PLACED = 0;
   AUTOFALL_DELAY = SPEED_MAP[GAME_SPEED];
   $('#speed .button').each(function () {


### PR DESCRIPTION
## Summary
- ensure demo mode runs at minimum speed 1 when SPEED is set to 0

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686169cc2cac832da9ff5d8a761136dd