### PR TITLE
Adjust sprite background-size to match 9-block sprite sheet

### DIFF
--- a/tetris.css
+++ b/tetris.css
@@ -233,7 +233,7 @@ button:active {
     border: none;
     background-image: url('https://i.imgur.com/GrIgPHU.png');
     background-repeat: no-repeat;
-    background-size: calc(var(--unit) * 8) var(--unit);
+    background-size: calc(var(--unit) * 9) var(--unit);
     image-rendering: pixelated;
 }
 


### PR DESCRIPTION
### Motivation
- The block sprite sheet contains 9 frames horizontally, so the previous sizing caused incorrect sprite alignment.
- Update ensures each block uses the correct portion of the sprite sheet when rendered at `var(--unit)` size.

### Description
- Changed `background-size` in `tetris.css` from `calc(var(--unit) * 8) var(--unit)` to `calc(var(--unit) * 9) var(--unit)` for `#tetris-area > div`, `#tetris-nextpuzzle > div`, and `.active-block` selectors.
- Kept sprite source `url('https://i.imgur.com/GrIgPHU.png')` and existing color mapping via `background-position-x` unchanged.
- Committed the CSS update and generated a visual snapshot of the running UI to verify rendering.

### Testing
- Served the project with `python -m http.server 8000` and the server started successfully. 
- Ran a Playwright script to open `index.html` and capture `artifacts/tetris-css-update.png`, which completed and produced the screenshot. 
- Verified the CSS change with a search (`rg -n "background-size" tetris.css`) and committed the change with `git commit`, both of which succeeded.
- No unit tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952b733a3f0832d8408bca81cb605f3)