### PR TITLE
Add game-over random destruction animation and blinking title

### DIFF
--- a/tetris.css
+++ b/tetris.css
@@ -272,8 +272,16 @@ button:active {
 }
 
 .destruct-anim {
-    animation: flash-destruct 0.4s forwards ease-out;
+    animation: flash-destruct 0.2s forwards ease-out;
     z-index: 100;
+}
+
+/* --- ANIMACIÓN PARPADEO TEXTO (Game Over) --- */
+@keyframes blink-text {
+    0% { opacity: 1; }
+    49% { opacity: 1; }
+    50% { opacity: 0; }
+    100% { opacity: 0; }
 }
 
 /* Ghost */
@@ -380,7 +388,10 @@ button:active {
     text-align: center;
 }
 
-#tetris-gameover h2 { color: #ff0000; }
+#tetris-gameover h2 {
+    color: #ff0000;
+    animation: blink-text 0.8s infinite;
+}
 #tetris-gameover .final-score { color: #ffff00; }
 
 /* Bot Status */


### PR DESCRIPTION
### Motivation
- Reproduce the reference "destruction on loss" effect by clearing the board block-by-block before showing the final screen to improve visual feedback.
- Make the `GAME OVER` title more visible with a blinking effect to match the arcade style and draw player attention.
- Prevent player/bot input and game logic from continuing while the game-over animation runs to avoid state corruption.
- Provide a clear, recoverable fast-fail sequence when the board is invalid during lock/spawn phases.

### Description
- CSS: added `@keyframes blink-text`, applied it to `#tetris-gameover h2`, and sped up `.destruct-anim` in `tetris.css` to make the flash/destruction more noticeable.
- JS: introduced `isGameOverAnimating` plus `triggerGameOver` and `runGameOverDestruction` in `tetris.js` to drive a randomized per-block destruction sequence and mark animating blocks with a sentinel value (`-2`).
- JS: updated `render` to display `.destruct-anim` for cells marked `-2`, and added guards throughout (`spawnNewPiece`, input handlers, `loop`, `applyBot` flows) to block actions while `isGameOverAnimating` is true. 
- JS: wired `reset`, `togglePause`, and `lockPiece` to use the new flow and to call `triggerGameOver` instead of immediately showing the modal in failure cases. 

### Testing
- Launched a local HTTP server and executed a Playwright script that injected and displayed the `#tetris-gameover` modal, then captured a screenshot (`artifacts/game-over-blink.png`), and the run completed successfully.
- Verified the repository changes were staged and committed (`tetris.css`, `tetris.js`) as part of the automated workflow.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952ba5a07c0832d895f6535fbca5393)