### PR TITLE
Migrate Tetris UI to light theme

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,16 +25,8 @@
                         <div class="value" id="tetris-stats-score">0</div>
                     </div>
                     <div class="stat-card">
-                        <label>Level</label>
-                        <div class="value" id="tetris-stats-level">1</div>
-                    </div>
-                    <div class="stat-card">
                         <label>Lines</label>
                         <div class="value" id="tetris-stats-lines">0</div>
-                    </div>
-                    <div class="stat-card">
-                        <label>APM</label>
-                        <div class="value" id="tetris-stats-apm">0</div>
                     </div>
                 </div>
 
@@ -48,21 +40,10 @@
                     <button class="btn-secondary" id="newGameBtn">↻ New Game</button>
                 </div>
 
-                <div class="win95-block settings-panel">
-                    <div class="settings-header">
-                        <p>Game Modes</p>
-                        <button class="toggle-btn" title="Settings">⚙️</button>
-                    </div>
-
-                    <div class="mode-switches" id="modeList">
-                        <div class="switch-group">
-                            <label for="iaAssistToggle">IA-ASSIST</label>
-                            <button type="button" class="switch" id="iaAssistToggle"></button>
-                        </div>
-                        <div class="switch-group">
-                            <label for="zenToggle">Zen Mode</label>
-                            <button type="button" class="switch" id="zenToggle"></button>
-                        </div>
+                <div class="win95-block mode-switches">
+                    <div class="switch-group">
+                        <label for="iaAssistToggle">IA-ASSIST</label>
+                        <button type="button" class="switch" id="iaAssistToggle"></button>
                     </div>
                 </div>
 
@@ -70,12 +51,11 @@
                     <div class="bot-settings-header" style="text-align: center; margin-bottom: 5px;">
                         🤖 IA MODE
                     </div>
-                    <div id="bot-strategy-indicator" class="bot-strategy balanced" style="font-size: 0.65rem; padding: 6px; border: 2px inset #fff; background: #222; text-align: center;">
+                    <div id="bot-strategy-indicator" class="bot-strategy balanced">
                         ANALIZANDO...
                     </div>
                 </div>
 
-                <button class="btn-secondary" id="audioBtn">🔊 Sound On</button>
             </div>
             <div class="game-section">
                 <div class="left-column" style="display: flex; flex-direction: column; gap: 10px;">
@@ -103,25 +83,6 @@
                     </div>
                 </div>
             </div>
-        </div>
-
-        <div id="tetris-keys" style="display: none;"></div>
-
-        <div style="display: none;">
-            <div id="tetris-help"></div>
-            <div id="tetris-highscores">
-                <div id="tetris-highscores-content"></div>
-                <span id="tetris-highscores-close"></span>
-            </div>
-            <span id="tetris-help-close"></span>
-
-            <button id="tetris-menu-start"></button>
-            <div id="tetris-pause"><button id="tetris-menu-pause"></button></div>
-            <div id="tetris-resume"><button id="tetris-menu-resume"></button></div>
-            <button id="tetris-menu-help"></button>
-            <button id="tetris-menu-highscores"></button>
-
-            <input type="checkbox" id="tetris-zen-mode">
         </div>
 
         <div id="tetris-gameover" style="display:none;"></div>

--- a/tetris.css
+++ b/tetris.css
@@ -4,10 +4,24 @@
     --unit: 20px;
     --area-x: 12;
     --area-y: 22;
-    /* Colores del código de referencia */
-    --bg-color: #111;
-    --panel-border: #fff;
-    --text-color: #fff;
+
+    /* Paleta clara */
+    --bg:        #f4f4f2;   /* no #fff puro: encandila con Press Start 2P */
+    --panel:     #ffffff;
+    --panel-2:   #fafafa;
+    --border:    #222222;   /* borde oscuro grueso = ADN arcade */
+    --text:      #1a1a1a;
+    --text-dim:  #555555;
+    --accent:    #3949ab;   /* PARAM_ACCENT */
+    --accent-2:  #00838f;   /* teal: reemplaza el cyan #00e5ff */
+    --log:       #1a7f37;   /* verde legible en claro */
+    --danger:    #d32f2f;
+    --grid-line: rgba(0, 0, 0, 0.08);
+
+    /* Alias de compatibilidad (reglas viejas siguen funcionando) */
+    --bg-color:     var(--bg);
+    --panel-border: var(--border);
+    --text-color:   var(--text);
 }
 
 * {
@@ -43,26 +57,26 @@ body {
 .header {
     text-align: center;
     padding: 10px;
-    background: #000;
+    background: var(--panel);
     border: 2px solid var(--panel-border);
     text-transform: uppercase;
 }
 
 .header h1 {
     font-size: 1.5rem;
-    color: #fff;
-    text-shadow: 2px 2px 0 #333;
+    color: var(--text);
+    text-shadow: 2px 2px 0 rgba(0, 0, 0, 0.15);
     margin-bottom: 5px;
 }
 
 .header p,
 .header .version {
     font-size: 0.6rem;
-    color: #aaa;
+    color: var(--text-dim);
 }
 
 #mode-status {
-    color: #ffcc00;
+    color: var(--accent);
     font-size: 0.7rem;
     margin-top: 5px;
 }
@@ -78,7 +92,7 @@ body {
 /* Paneles Laterales */
 .control-panel,
 .game-section {
-    background: #000;
+    background: var(--bg);
     border: 2px solid var(--panel-border);
     padding: 15px;
 }
@@ -90,16 +104,22 @@ body {
 }
 
 .win95-block {
-    background: #000;
-    border: 1px solid #444;
+    background: var(--panel);
+    border: 1px solid #ddd;
     padding: 10px;
     box-shadow: none;
 }
 
 /* Estadísticas */
+.stats-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 10px;
+}
+
 .stat-card label,
 .timer-box label {
-    color: #aaa;
+    color: var(--text-dim);
     font-size: 0.6rem;
     margin-bottom: 5px;
     display: block;
@@ -107,7 +127,7 @@ body {
 
 .stat-card .value,
 .timer-box .value {
-    color: #fff;
+    color: var(--text);
     font-size: 1rem;
 }
 
@@ -116,35 +136,35 @@ button {
     font-family: inherit;
     font-size: 0.6rem;
     padding: 10px;
-    border: 2px solid #fff;
-    background: #000;
-    color: #fff;
+    border: 2px solid var(--border);
+    background: var(--panel);
+    color: var(--text);
     cursor: pointer;
     text-transform: uppercase;
     transition: background 0.1s;
 }
 
 button:hover {
-    background: #333;
+    background: #ececec;
 }
 
 button:active {
-    background: #555;
+    background: #dddddd;
 }
 
 .btn-primary {
-    border-color: #ffcc00;
-    color: #ffcc00;
+    border-color: var(--accent);
+    color: var(--accent);
 }
 
 .btn-secondary {
-    border-color: #fff;
+    border-color: var(--border);
 }
 
 /* Interruptores */
 .switch {
-    background: #000;
-    border: 2px solid #555;
+    background: var(--panel);
+    border: 2px solid #999;
     position: relative;
     width: 40px;
     height: 18px;
@@ -158,25 +178,20 @@ button:active {
     left: 2px;
     width: 12px;
     height: 12px;
-    background: #555;
+    background: #dddddd;
     transition: transform 0.2s ease;
 }
 
 .switch.active {
-    border-color: #00e5ff !important;
-    background-color: #000 !important;
+    border-color: var(--accent-2) !important;
+    background-color: var(--panel) !important;
 }
 
 .switch.active::after {
-    background: #00e5ff;
+    background: var(--accent-2);
     transform: translateX(20px);
 }
 
-.toggle-btn {
-    font-size: 0.7rem;
-    line-height: 1;
-    padding: 6px 10px;
-}
 
 /* --- TABLERO Y PIEZAS (SPRITES) --- */
 
@@ -194,12 +209,12 @@ button:active {
     justify-content: center;
     align-items: center;
     height: 100%;
-    background: #000;
+    background: var(--panel);
 }
 
 .game-board {
-    background: #000;
-    border: 2px solid #fff;
+    background: var(--panel);
+    border: 2px solid var(--border);
     position: relative;
     overflow: hidden;
     box-shadow: 0 0 20px rgba(0, 0, 0, 0.5);
@@ -210,8 +225,8 @@ button:active {
 
 .game-grid {
     background-image:
-        linear-gradient(rgba(255, 255, 255, 0.05) 1px, transparent 1px),
-        linear-gradient(90deg, rgba(255, 255, 255, 0.05) 1px, transparent 1px);
+        linear-gradient(var(--grid-line) 1px, transparent 1px),
+        linear-gradient(90deg, var(--grid-line) 1px, transparent 1px);
     background-size: var(--unit) var(--unit);
 }
 
@@ -231,6 +246,8 @@ button:active {
     position: absolute;
     box-sizing: border-box;
     border: none;
+    outline: 1px solid rgba(0, 0, 0, 0.28);
+    outline-offset: -1px;
     background-image: url('https://i.imgur.com/GrIgPHU.png');
     background-repeat: no-repeat;
     background-size: calc(var(--unit) * 9) var(--unit);
@@ -259,7 +276,7 @@ button:active {
     }
     25% {
         filter: brightness(10) sepia(1);
-        background-color: #fff;
+        background-color: var(--accent);
     }
     50% {
         opacity: 1;
@@ -287,21 +304,21 @@ button:active {
 /* Ghost */
 .bot-ghost {
     opacity: 0.3;
-    border: 1px solid #fff !important;
+    border: 1px solid var(--border) !important;
     background-image: none !important;
 }
 
 .bot-controlled {
-    filter: drop-shadow(0 0 8px rgba(0, 229, 255, 0.8));
+    filter: drop-shadow(0 0 6px rgba(0, 131, 143, 0.55));
 }
 
 /* Next Piece Box */
 .inline-next-piece {
     position: relative;
     width: calc(var(--unit) * 7.5);
-    background: #000;
-    border: 2px solid #fff;
-    color: #fff;
+    background: var(--panel);
+    border: 2px solid var(--border);
+    color: var(--text);
     padding: 10px;
     z-index: 20;
     height: max-content;
@@ -321,7 +338,7 @@ button:active {
 
 .next-piece-box {
     border: none;
-    background: #000;
+    background: var(--panel);
     width: calc(var(--unit) * 7.5);
     height: calc(var(--unit) * 6);
     transform: scale(0.7);
@@ -335,17 +352,17 @@ button:active {
 /* Logs */
 .log-panel {
     width: calc(var(--unit) * 7.5);
-    background: #111;
-    border: 1px solid #333;
-    color: #0f0;
+    background: var(--panel-2);
+    border: 1px solid #ccc;
+    color: var(--log);
     padding: 6px;
     font-family: 'Courier New', monospace;
 }
 
 .log-panel p {
-    color: #fff;
+    color: var(--text);
     margin-bottom: 5px;
-    border-bottom: 1px solid #555;
+    border-bottom: 1px solid #ccc;
     padding-bottom: 2px;
     text-align: center;
 }
@@ -365,9 +382,9 @@ button:active {
     opacity: 0.8;
 }
 
-.log-entry.solid { border-color: #0f0; color: #cfc; }
-.log-entry.broken { border-color: #f00; color: #fcc; }
-.placeholder { color: #555; font-style: italic; border: none; }
+.log-entry.solid { border-color: var(--log); color: #1a7f37; }
+.log-entry.broken { border-color: var(--danger); color: var(--danger); }
+.placeholder { color: var(--text-dim); font-style: italic; border: none; }
 
 /* Game Over Modal */
 #tetris-gameover {
@@ -375,9 +392,9 @@ button:active {
     top: 50%;
     left: 50%;
     transform: translate(-50%, -50%);
-    background: #000;
-    border: 4px solid #fff;
-    color: #fff;
+    background: var(--panel);
+    border: 4px solid var(--border);
+    color: var(--text);
     padding: 20px;
     width: 250px;
     z-index: 200;
@@ -389,31 +406,27 @@ button:active {
 }
 
 #tetris-gameover h2 {
-    color: #ff0000;
+    color: var(--danger);
     animation: blink-text 0.8s infinite;
 }
-#tetris-gameover .final-score { color: #ffff00; }
+#tetris-gameover .final-score { color: var(--accent); }
 
 /* Bot Status */
 #bot-strategy-indicator {
-    background: #222;
-    border: 1px solid #555;
-    color: #0f0;
+    background: var(--panel-2);
+    border: 1px solid #ccc;
+    color: var(--log);
     font-size: 0.6rem;
     padding: 4px 8px;
     text-align: center;
 }
 
-.bot-strategy.survival { color: #e74c3c; }
-.bot-strategy.tetris { color: #2ecc71; }
-.bot-strategy.attack { color: #f39c12; }
 .bot-strategy.balanced { color: #4a90e2; }
-.bot-strategy.zen { color: #9b59b6; }
 
 @keyframes blink-green {
-    0% { background-color: #222; color: #fff; border-color: #fff; }
+    0% { background-color: var(--panel-2); color: var(--text); border-color: #ccc; }
     50% { background-color: #00ff00; color: #000; border-color: #00ff00; box-shadow: 0 0 8px #00ff00; }
-    100% { background-color: #222; color: #fff; border-color: #fff; }
+    100% { background-color: var(--panel-2); color: var(--text); border-color: #ccc; }
 }
 
 .bot-thinking {
@@ -422,8 +435,8 @@ button:active {
 }
 
 .bot-idle {
-    background-color: #222;
-    color: #888;
+    background-color: var(--panel-2);
+    color: var(--text-dim);
 }
 
 .game-message {
@@ -432,19 +445,19 @@ button:active {
     left: 50%;
     transform: translateX(-50%);
     padding: 4px 8px;
-    background: rgba(0, 0, 0, 0.7);
-    border: 1px solid #555;
+    background: rgba(255, 255, 255, 0.9);
+    border: 1px solid var(--border);
     font-size: 0.6rem;
     pointer-events: none;
 }
 
 .game-message.idle {
-    color: #aaa;
+    color: var(--text-dim);
     opacity: 0.8;
 }
 
 .game-message.active {
-    color: #00e5ff;
+    color: var(--accent-2);
     opacity: 1;
 }
 

--- a/tetris.js
+++ b/tetris.js
@@ -1222,15 +1222,18 @@ class TetrisGame {
     const btn = document.getElementById('playBtn'); // Referencia al botón
 
     if (this.paused) {
+      document.getElementById('gameMessage')?.style.setProperty('display', 'block');
       this.pauseTimer();
       if (btn) btn.textContent = '▶ Play'; // Cambio visual a Play
     } else if (!this.gameOver) {
+      document.getElementById('gameMessage')?.style.setProperty('display', 'none');
       this.resumeTimer();
       if (btn) btn.textContent = '⏸ Pause'; // Cambio visual a Pause
     }
   }
 
   showGameOverScreen() {
+    document.getElementById('gameMessage')?.style.setProperty('display', 'block');
     const el = document.getElementById('tetris-gameover');
     if (!el) return;
 
@@ -1252,6 +1255,7 @@ class TetrisGame {
   reset() {
     const goScreen = document.getElementById('tetris-gameover');
     if (goScreen) goScreen.style.display = 'none';
+    document.getElementById('gameMessage')?.style.setProperty('display', 'block');
     this.gameOver = false;
     this.isGameOverAnimating = false;
     this.board = Array.from({length: ROWS}, () => Array(COLS).fill(-1));


### PR DESCRIPTION
### Motivation
- Modernize the Tetris UI to a readable light theme while keeping the original arcade visual language and preserving JS-referenced DOM IDs to avoid runtime breakage.
- Remove dead legacy HTML and visual cruft to simplify the UI and reduce surface area for bugs while keeping IA-ASSIST and protected controls intact.
- Introduce CSS tokens to make future theme tweaks safe and incremental without touching game logic.

### Description
- HTML: removed unused controls and legacy hidden nodes (`audioBtn`, `tetris-stats-level`, `tetris-stats-apm`, legacy hidden block, `tetris-keys`) and replaced the settings panel with a reduced IA-ASSIST-only `mode-switches` block, while preserving all protected IDs referenced by the game code (score, lines, time, `playBtn`, `newGameBtn`, `iaAssistToggle`, `mode-status`, `bot-strategy-indicator`, `tetris-nextpuzzle`, `tetris-area`, `gameGrid`, `wall-logs`, `tetris-gameover`).
- CSS: replaced the `:root` block with a light-theme token palette and added compatibility aliases; migrated many hardcoded colors to tokens (panels, text, borders, buttons, logs, modal, bot indicator); added `.stats-grid` layout and removed orphan rules; added sprite visibility fixes (`outline` + `outline-offset`) and adjusted ghost border, bot glow intensity, destruction flash color, blink animation frames, and `.game-message` styling for light backgrounds.
- JS: wired `#gameMessage` visibility using guarded DOM access (`document.getElementById('gameMessage')?.style.setProperty('display', ...)`) for `togglePause()`, `showGameOverScreen()` and `reset()` so the persistent PRESS START node is hidden/shown safely without throwing if the node is absent.
- Fast-fail safety: preserved and validated the list of protected IDs and left `iaAssistToggle` behavior intact; added minor bot-cleanup logic kept in place to avoid action queue leaks (existing in `bindEvents`).

### Testing
- Verified all protected IDs remain present in `index.html` using a grep loop, and this check passed for each ID (`OK`).
- Confirmed removed legacy HTML references are absent by running `grep -E "audioBtn|tetris-stats-level|tetris-stats-apm|zenToggle|toggle-btn|tetris-keys|tetris-help|tetris-highscores|tetris-menu|tetris-pause|tetris-resume|tetris-zen-mode" index.html`, which returned no matches.
- Checked CSS for orphaned selectors (`toggle-btn` and unused `.bot-strategy.*` variants) with `rg` and ensured none of the disallowed rules remain; this check passed.
- Performed static JS verification with `node --check tetris.js`, which succeeded with no syntax errors.
- Attempted a local HTTP smoke test (`curl -I http://127.0.0.1:8000/index.html`) and browser automation was unavailable in the environment, so the runtime render / visual smoke test could not be completed here (environment limitation).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a491c3cd28c832da5b6ecf05fdbc47c)