### PR TITLE
Apply Windows 98 UI chrome, consolidate layout into 5 windows, and fix Next Piece rendering

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,83 +12,102 @@
 
 <body>
     <div class="container">
-        <div class="header">
-            <h1>TETRIS <span class="version">v8.5</span></h1>
-            <p>Experience the Classic</p>
-            <div id="mode-status">MODO: MANUAL</div>
-        </div>
         <div class="main-grid">
             <div class="control-panel">
-                <div class="win95-block stats-grid">
-                    <div class="stat-card highlight">
-                        <label>Score</label>
-                        <div class="value" id="tetris-stats-score">0</div>
+                <section class="win98-window stats-window">
+                    <div class="win98-titlebar">
+                        <span class="title">📊 Estadísticas</span>
+                        <span class="win-btns"><button>_</button><button>▢</button><button>✕</button></span>
                     </div>
-                    <div class="stat-card">
-                        <label>Lines</label>
-                        <div class="value" id="tetris-stats-lines">0</div>
+                    <div class="win98-client">
+                        <div class="stats-grid">
+                            <div class="stat-card highlight">
+                                <label>Score</label>
+                                <div class="value win98-inset" id="tetris-stats-score">0</div>
+                            </div>
+                            <div class="stat-card">
+                                <label>Lines</label>
+                                <div class="value win98-inset" id="tetris-stats-lines">0</div>
+                            </div>
+                            <div class="timer-box">
+                                <label>Time</label>
+                                <div class="value win98-inset" id="tetris-stats-time">0:00</div>
+                            </div>
+                        </div>
                     </div>
-                </div>
+                </section>
 
-                <div class="win95-block timer-box">
-                    <label>Time</label>
-                    <div class="value" id="tetris-stats-time">0:00</div>
-                </div>
-
-                <div class="win95-block controls">
-                    <button class="btn-primary" id="playBtn">▶ Play</button>
-                    <button class="btn-secondary" id="newGameBtn">↻ New Game</button>
-                </div>
-
-                <div class="win95-block mode-switches">
-                    <div class="switch-group">
-                        <label for="iaAssistToggle">IA-ASSIST</label>
-                        <button type="button" class="switch" id="iaAssistToggle"></button>
+                <section class="win98-window control-window">
+                    <div class="win98-titlebar">
+                        <span class="title">🎮 Control IA</span>
+                        <span class="win-btns"><button>_</button><button>▢</button><button>✕</button></span>
                     </div>
-                </div>
-
-                <div class="win95-block bot-settings" id="botSettings">
-                    <div class="bot-settings-header" style="text-align: center; margin-bottom: 5px;">
-                        🤖 IA MODE
+                    <div class="win98-client control-stack">
+                        <div class="controls">
+                            <button class="btn-primary" id="playBtn">▶ Play</button>
+                            <button class="btn-secondary" id="newGameBtn">↻ New Game</button>
+                        </div>
+                        <div class="mode-switches">
+                            <div class="switch-group">
+                                <label for="iaAssistToggle">IA-ASSIST</label>
+                                <button type="button" class="switch" id="iaAssistToggle"></button>
+                            </div>
+                        </div>
+                        <div class="bot-settings" id="botSettings">
+                            <div class="bot-settings-header">🤖 IA MODE</div>
+                            <div id="bot-strategy-indicator" class="bot-strategy balanced win98-inset">ANALIZANDO...</div>
+                        </div>
                     </div>
-                    <div id="bot-strategy-indicator" class="bot-strategy balanced">
-                        ANALIZANDO...
-                    </div>
-                </div>
+                </section>
 
-            </div>
-            <div class="game-section">
-                <div class="left-column" style="display: flex; flex-direction: column; gap: 10px;">
-                    <div class="inline-next-piece win95-block">
-                        <p>Next Piece</p>
-                        <div class="next-piece-box" id="tetris-nextpuzzle"></div>
+                <section class="win98-window inline-next-piece">
+                    <div class="win98-titlebar">
+                        <span class="title">🧩 Próxima Pieza</span>
+                        <span class="win-btns"><button>_</button><button>▢</button><button>✕</button></span>
                     </div>
+                    <div class="win98-client">
+                        <div class="next-piece-box win98-inset" id="tetris-nextpuzzle"></div>
+                    </div>
+                </section>
 
-                    <div class="win95-block log-panel">
-                        <p>Wall Integrity</p>
-                        <div id="wall-logs" class="log-content">
+                <section class="win98-window log-panel">
+                    <div class="win98-titlebar">
+                        <span class="title">🧱 Wall Integrity</span>
+                        <span class="win-btns"><button>_</button><button>▢</button><button>✕</button></span>
+                    </div>
+                    <div class="win98-client">
+                        <div id="wall-logs" class="log-content win98-inset">
                             <div class="log-entry placeholder">Esperando datos...</div>
                         </div>
                     </div>
-                </div>
+                </section>
+            </div>
 
-                <div class="game-board-wrapper">
-                    <div class="game-board">
-                        <div class="game-grid" id="gameGrid"></div>
-                        <div id="tetris-area"></div>
-                        <div class="game-message idle" id="gameMessage">
-                            <h2>PRESS START</h2>
-                            <p>Ready to play?</p>
+            <div class="game-section">
+                <section class="win98-window tetris-window">
+                    <div class="win98-titlebar">
+                        <span class="title">🕹️ Tetris.exe v8.5</span>
+                        <span class="win-btns"><button>_</button><button>▢</button><button>✕</button></span>
+                    </div>
+                    <div class="win98-client">
+                        <div class="game-board-wrapper">
+                            <div class="game-board win98-inset">
+                                <div class="game-grid" id="gameGrid"></div>
+                                <div id="tetris-area"></div>
+                                <div class="game-message idle" id="gameMessage">
+                                    <h2>PRESS START</h2>
+                                    <p>Ready to play?</p>
+                                </div>
+                            </div>
                         </div>
                     </div>
-                </div>
+                    <div class="win98-statusbar" id="mode-status">MODO: MANUAL</div>
+                </section>
             </div>
         </div>
 
         <div id="tetris-gameover" style="display:none;"></div>
     </div>
-
-    
 </body>
 
 </html>

--- a/tetris.css
+++ b/tetris.css
@@ -5,25 +5,40 @@
     --area-x: 12;
     --area-y: 22;
 
-    /* Paleta clara */
-    --bg:        #f4f4f2;   /* no #fff puro: encandila con Press Start 2P */
-    --panel:     #ffffff;
-    --panel-2:   #fafafa;
-    --border:    #222222;   /* borde oscuro grueso = ADN arcade */
-    --text:      #1a1a1a;
-    --text-dim:  #555555;
-    --accent:    #3949ab;   /* PARAM_ACCENT */
-    --accent-2:  #00838f;   /* teal: reemplaza el cyan #00e5ff */
-    --log:       #1a7f37;   /* verde legible en claro */
-    --danger:    #d32f2f;
-    --grid-line: rgba(0, 0, 0, 0.08);
+    /* Superficie Win98 */
+    --win-face:     #c0c0c0;
+    --win-hl:       #ffffff;
+    --win-light:    #dfdfdf;
+    --win-shadow:   #808080;
+    --win-dark:     #000000;
 
-    /* Alias de compatibilidad (reglas viejas siguen funcionando) */
-    --bg-color:     var(--bg);
-    --panel-border: var(--border);
+    /* Barra de título (Win98 = degradé) */
+    --title-1:      #000080;
+    --title-2:      #1084d0;
+    --title-text:   #ffffff;
+    --title-inactive-1: #808080;
+    --title-inactive-2: #b5b5b5;
+
+    /* Contenido */
+    --text:         #000000;
+    --text-dim:     #404040;
+    --accent:       #000080;
+    --accent-2:     #008080;
+    --log:          #008000;
+    --danger:       #aa0000;
+    --disabled:     #808080;
+    --grid-line:    rgba(0, 0, 0, 0.12);
+    --desktop:      #008080;
+
+    /* Alias de compatibilidad */
+    --bg:           var(--desktop);
+    --panel:        var(--win-face);
+    --panel-2:      var(--win-face);
+    --border:       var(--win-dark);
+    --bg-color:     var(--desktop);
+    --panel-border: var(--win-dark);
     --text-color:   var(--text);
 }
-
 * {
     margin: 0;
     padding: 0;
@@ -465,3 +480,221 @@ button:active {
 .footer {
     display: none !important;
 }
+
+/* --- Windows 98 chrome consolidation --- */
+body { background: var(--desktop); }
+
+.container { max-width: 1120px; gap: 8px; }
+
+.win98-window {
+    background: var(--win-face);
+    padding: 2px;
+    box-shadow:
+        inset -1px -1px 0 0 var(--win-dark),
+        inset  1px  1px 0 0 var(--win-hl),
+        inset -2px -2px 0 0 var(--win-shadow),
+        inset  2px  2px 0 0 var(--win-light);
+}
+
+.win98-titlebar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 4px;
+    padding: 2px 2px 2px 4px;
+    background: linear-gradient(90deg, var(--title-1), var(--title-2));
+    color: var(--title-text);
+    font-size: 0.45rem;
+    line-height: 1.4;
+    text-transform: none;
+}
+.win98-titlebar .title { display: flex; align-items: center; gap: 4px; }
+.win98-titlebar .win-btns { display: flex; gap: 2px; }
+.win98-titlebar .win-btns button {
+    width: 16px;
+    height: 14px;
+    padding: 0;
+    font-size: 0.5rem;
+    line-height: 1;
+    background: var(--win-face);
+    color: var(--disabled);
+    box-shadow:
+        inset -1px -1px 0 0 var(--win-dark),
+        inset  1px  1px 0 0 var(--win-hl),
+        inset -2px -2px 0 0 var(--win-shadow),
+        inset  2px  2px 0 0 var(--win-light);
+    opacity: 0.55;
+    pointer-events: none;
+    cursor: default;
+}
+.win98-client { padding: 8px; }
+.win98-inset {
+    background: var(--win-face);
+    box-shadow:
+        inset  1px  1px 0 0 var(--win-dark),
+        inset -1px -1px 0 0 var(--win-hl),
+        inset  2px  2px 0 0 var(--win-shadow),
+        inset -2px -2px 0 0 var(--win-light);
+}
+.win98-statusbar {
+    margin: 4px 2px 2px;
+    padding: 2px 6px;
+    font-size: 0.45rem;
+    color: var(--text);
+    box-shadow:
+        inset  1px  1px 0 0 var(--win-shadow),
+        inset -1px -1px 0 0 var(--win-hl);
+}
+
+.main-grid { grid-template-columns: 300px 1fr; gap: 8px; }
+.control-panel {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    justify-content: center;
+    background: transparent;
+    border: none;
+    padding: 8px;
+}
+.game-section {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    background: transparent;
+    border: none;
+    padding: 8px;
+    gap: 0;
+}
+
+.stats-grid { grid-template-columns: 1fr 1fr; gap: 8px; }
+.timer-box { grid-column: 1 / -1; }
+.stat-card .value,
+.timer-box .value {
+    padding: 8px 6px;
+    margin-top: 5px;
+    min-height: 28px;
+}
+.control-stack,
+.controls,
+.mode-switches,
+.bot-settings { display: flex; flex-direction: column; gap: 8px; }
+.bot-settings-header { text-align: center; margin-bottom: 0; color: var(--text-dim); font-size: 0.5rem; }
+.switch-group { display: flex; align-items: center; justify-content: space-between; gap: 8px; font-size: 0.55rem; }
+
+button {
+    border: none;
+    background: var(--win-face);
+    color: var(--text);
+    box-shadow:
+        inset -1px -1px 0 0 var(--win-dark),
+        inset  1px  1px 0 0 var(--win-hl),
+        inset -2px -2px 0 0 var(--win-shadow),
+        inset  2px  2px 0 0 var(--win-light);
+}
+button:hover { background: var(--win-light); }
+button:active {
+    background: var(--win-face);
+    box-shadow:
+        inset  1px  1px 0 0 var(--win-dark),
+        inset -1px -1px 0 0 var(--win-hl),
+        inset  2px  2px 0 0 var(--win-shadow),
+        inset -2px -2px 0 0 var(--win-light);
+}
+.btn-primary, .btn-secondary { color: var(--text); }
+
+.switch {
+    border: none;
+    box-shadow:
+        inset  1px  1px 0 0 var(--win-dark),
+        inset -1px -1px 0 0 var(--win-hl),
+        inset  2px  2px 0 0 var(--win-shadow),
+        inset -2px -2px 0 0 var(--win-light);
+}
+.switch::after { background: var(--win-light); }
+.switch.active { border-color: transparent !important; background-color: var(--win-face) !important; }
+.switch.active::after { background: var(--accent-2); }
+
+.tetris-window { width: max-content; }
+.game-board-wrapper { height: calc(var(--unit) * var(--area-y)); background: transparent; }
+.game-board {
+    border: none;
+    box-shadow:
+        inset  1px  1px 0 0 var(--win-dark),
+        inset -1px -1px 0 0 var(--win-hl),
+        inset  2px  2px 0 0 var(--win-shadow),
+        inset -2px -2px 0 0 var(--win-light);
+}
+.game-grid { position: absolute; inset: 0; width: 100%; height: 100%; }
+
+.inline-next-piece,
+.log-panel {
+    width: 100%;
+    border: none;
+    padding: 2px;
+    align-self: auto;
+    display: block;
+    font-family: inherit;
+}
+.inline-next-piece p,
+.log-panel p { display: none; }
+.next-piece-box {
+    width: calc(var(--unit) * 6);
+    height: calc(var(--unit) * 5);
+    transform: none;
+    transform-origin: initial;
+    position: relative;
+    margin: 0 auto;
+}
+.log-content {
+    height: 100px;
+    padding: 6px;
+    color: var(--log);
+}
+.log-entry.solid { border-color: var(--log); color: var(--log); }
+.log-entry.broken { border-color: var(--danger); color: var(--danger); }
+
+#bot-strategy-indicator {
+    border: none;
+    color: var(--log);
+    padding: 6px 8px;
+}
+.bot-strategy.balanced { color: var(--log); }
+.bot-idle { background-color: var(--win-face); color: var(--text-dim); }
+@keyframes blink-green {
+    0% { background: var(--win-face); color: var(--text); }
+    50% { background: #00ff00; color: #000000; box-shadow: 0 0 8px #00ff00; }
+    100% { background: var(--win-face); color: var(--text); }
+}
+
+.game-message {
+    background: var(--win-face);
+    border: none;
+    box-shadow:
+        inset  1px  1px 0 0 var(--win-dark),
+        inset -1px -1px 0 0 var(--win-hl);
+    text-align: center;
+}
+
+#tetris-gameover {
+    border: none;
+    padding: 22px 12px 12px;
+    background: var(--win-face);
+    box-shadow:
+        inset -1px -1px 0 0 var(--win-dark),
+        inset  1px  1px 0 0 var(--win-hl),
+        inset -2px -2px 0 0 var(--win-shadow),
+        inset  2px  2px 0 0 var(--win-light);
+}
+#tetris-gameover::before {
+    content: 'Game Over';
+    position: absolute;
+    top: 2px;
+    left: 2px;
+    right: 2px;
+    padding: 2px 4px;
+    background: linear-gradient(90deg, var(--title-1), var(--title-2));
+    color: var(--title-text);
+    font-size: 0.45rem;
+    text-align: left;
+}
+#tetris-gameover .final-score { color: var(--accent); }

--- a/tetris.js
+++ b/tetris.js
@@ -517,18 +517,26 @@ class TetrisGame {
   }
 
   renderNext() {
+    if (!this.nextBox) {
+      console.warn('[AGENT][renderNext] Fast-Fail: contenedor #tetris-nextpuzzle no disponible.');
+      return;
+    }
     this.nextBox.innerHTML = '';
     if (!this.next) return;
     const matrix = this.next.shapes[0];
-    const offsetX = 2 - Math.floor(matrix[0].length / 2);
-    const offsetY = 2 - Math.floor(matrix.length / 2);
+    const w = matrix[0].length;
+    const h = matrix.length;
+    const COLS_BOX = 6;
+    const ROWS_BOX = 5;
+    const offsetX = (COLS_BOX - w) / 2;
+    const offsetY = (ROWS_BOX - h) / 2;
     matrix.forEach((row, dy) => {
       row.forEach((val, dx) => {
         if (val) {
           const div = document.createElement('div');
           div.className = BLOCK_CLASSES[this.next.typeId];
-          div.style.left = `${(dx + offsetX + 1) * UNIT}px`;
-          div.style.top = `${(dy + offsetY + 1) * UNIT}px`;
+          div.style.left = `${(dx + offsetX) * UNIT}px`;
+          div.style.top = `${(dy + offsetY) * UNIT}px`;
           this.nextBox.appendChild(div);
         }
       });


### PR DESCRIPTION
### Motivation
- Convert the UI to a Windows 98 chrome (titlebars, beveled windows and statusbar) and consolidate controls into a 5-window layout for clarity and visual consistency. 
- Make the Next Piece preview render at true 1:1 unit size (no CSS scaling) so preview pieces match the board, and center them in a fixed preview grid. 
- Harden DOM interactions with Fast-Fail guards to avoid runtime TypeErrors when optional nodes are absent while preserving all JS-facing IDs. 

### Description
- Replaced theme tokens in `:root` and added Win98 palette variables (`--win-face`, `--title-1`, `--desktop`, etc.) and aliases for compatibility. 
- Added reusable chrome styles (`.win98-window`, `.win98-titlebar`, `.win98-client`, `.win98-inset`, `.win98-statusbar`) and restyled buttons, panes, logs, gameover dialog and bot indicator to match the Win98 motif in `tetris.css`. 
- Rewrote the page body in `index.html` into five Win98-style windows (Estadísticas, Control IA, Próxima Pieza, Wall Integrity, Tetris.exe), moved `#mode-status` into the Tetris statusbar, and ensured all protected IDs remain present. 
- Changed Next Piece layout: `.next-piece-box` now sized to `calc(var(--unit) * 6)` × `calc(var(--unit) * 5)` with no `transform: scale`, and updated `renderNext()` in `tetris.js` to center tetrominoes inside a 6×5 preview box and include a Fast-Fail guard that logs a warning if the preview container is missing. 

### Testing
- `node --check tetris.js` was run and returned OK. 
- Protected ID presence was validated with a Python HTML parser script and all required IDs were found. 
- Legacy/forbidden identifiers (`audioBtn`, `tetris-stats-level`, `tetris-keys`, etc.) were scanned via Python and none were present. 
- `git diff --check` (style/error check) completed without reported issues and a local simple HTTP server served `index.html` successfully as verified by `curl -I` (HTTP 200). 
- Browser automation with Playwright could not be executed because Playwright is not installed in the environment (test skipped).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4923bbefec832db67a907484a74442)