### PR TITLE
Adjust Tetris board layout scaling

### DIFF
--- a/tetris.css
+++ b/tetris.css
@@ -102,6 +102,8 @@ body {
     grid-template-columns: 300px 1fr;
     gap: 20px;
     min-height: 0;
+    height: 100%;
+    align-items: stretch;
 }
 
 /* Paneles Laterales */
@@ -223,8 +225,11 @@ button:active {
     display: flex;
     justify-content: center;
     align-items: center;
-    height: 100%;
+    flex: 1;
+    min-height: 0;
     background: var(--panel);
+    padding: 10px;
+    box-sizing: border-box;
 }
 
 .game-board {
@@ -234,8 +239,10 @@ button:active {
     overflow: hidden;
     box-shadow: 0 0 20px rgba(0, 0, 0, 0.5);
     display: flex;
-    align-items: stretch;
+    align-items: center;
     justify-content: center;
+    max-height: 100%;
+    max-width: 100%;
 }
 
 .game-grid {
@@ -559,7 +566,9 @@ body { background: var(--desktop); }
 .game-section {
     display: flex;
     justify-content: center;
-    align-items: center;
+    align-items: stretch;
+    height: 100%;
+    min-height: 0;
     background: transparent;
     border: none;
     padding: 8px;
@@ -614,8 +623,19 @@ button:active {
 .switch.active { border-color: transparent !important; background-color: var(--win-face) !important; }
 .switch.active::after { background: var(--accent-2); }
 
-.tetris-window { width: max-content; }
-.game-board-wrapper { height: calc(var(--unit) * var(--area-y)); background: transparent; }
+.tetris-window {
+    display: flex;
+    flex-direction: column;
+    width: max-content;
+    height: 100%;
+    max-height: 100%;
+}
+.tetris-window .win98-client {
+    display: flex;
+    flex: 1;
+    min-height: 0;
+}
+.game-board-wrapper { background: transparent; }
 .game-board {
     border: none;
     box-shadow:

--- a/tetris.js
+++ b/tetris.js
@@ -16,8 +16,9 @@ function syncBoardScale(gameInstance = null) {
   if (!wrapper || !board) return;
 
   const wrapperHeight = wrapper.clientHeight;
-  if (!wrapperHeight) return;
-  const dynamicUnit = Math.floor(wrapperHeight / ROWS);
+  const wrapperWidth = wrapper.clientWidth;
+  if (!wrapperHeight || !wrapperWidth) return;
+  const dynamicUnit = Math.max(1, Math.floor(Math.min(wrapperHeight / ROWS, wrapperWidth / COLS)));
 
   document.documentElement.style.setProperty('--unit', `${dynamicUnit}px`);
   UNIT = dynamicUnit;


### PR DESCRIPTION
### Motivation
- Allow the Tetris window to consume the full available vertical space and remain centered in the UI without causing overflow or clipping. 
- Preserve the board aspect ratio when the container is resized by factoring both width and height into the scaling calculation. 

### Description
- Updated `tetris.css` to make the layout stretch vertically by adding `height: 100%` and `align-items: stretch` to `.main-grid` and making `.game-section`, `.game-board-wrapper` and `.tetris-window` flex containers with `height: 100%`/`min-height: 0` to avoid overflow. 
- Centered the board while bounding its size by changing `.game-board` alignment to `center` and adding `max-height: 100%` and `max-width: 100%`, and added padding/box-sizing to the wrapper for stable sizing. 
- Updated `syncBoardScale()` in `tetris.js` to compute `dynamicUnit` from both `wrapper.clientHeight` and `wrapper.clientWidth` using `Math.floor(Math.min(wrapperHeight / ROWS, wrapperWidth / COLS))` with a `Math.max(1, ...)` guard, and continue setting `--unit` plus explicit `board.style.width`/`height`. 

### Testing
- Ran `node --check tetris.js` which succeeded. 
- Performed a CSS selector sanity check via a Python snippet that verified presence of the modified selectors which succeeded. 
- Executed `git diff --check` to validate whitespace/format issues which returned no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a49aa27a478832d911af9169ffec3d9)