### PR TITLE
Preserve height-priority board scaling with width cap

### DIFF
--- a/tetris.js
+++ b/tetris.js
@@ -17,11 +17,23 @@ function syncBoardScale(gameInstance = null) {
 
   const wrapperHeight = wrapper.clientHeight;
   const wrapperWidth = wrapper.clientWidth;
+
   if (!wrapperHeight || !wrapperWidth) return;
-  const dynamicUnit = Math.max(1, Math.floor(Math.min(wrapperHeight / ROWS, wrapperWidth / COLS)));
+
+  // Prioridad: altura máxima, pero nunca exceder el ancho disponible.
+  let dynamicUnit = Math.floor(wrapperHeight / ROWS);
+
+  // Limitar si el ancho no alcanza (evita overflow horizontal).
+  const maxByWidth = Math.floor(wrapperWidth / COLS);
+  if (dynamicUnit > maxByWidth) {
+    dynamicUnit = maxByWidth;
+  }
+
+  dynamicUnit = Math.max(1, dynamicUnit);
 
   document.documentElement.style.setProperty('--unit', `${dynamicUnit}px`);
   UNIT = dynamicUnit;
+
   board.style.height = `${ROWS * dynamicUnit}px`;
   board.style.width = `${COLS * dynamicUnit}px`;
 


### PR DESCRIPTION
### Motivation
- Restore the original behavior where board scaling is driven primarily by container height while preventing horizontal overflow in narrow layouts.
- Ensure the board remains usable across responsive widths without changing existing render/update behavior.

### Description
- Change `syncBoardScale` to compute `dynamicUnit` from `Math.floor(wrapperHeight / ROWS)` so height is the primary constraint.
- Add a width-based cap using `const maxByWidth = Math.floor(wrapperWidth / COLS)` and clamp `dynamicUnit` to `maxByWidth` to avoid horizontal overflow.
- Keep the minimum unit guard `Math.max(1, ...)`, update the CSS `--unit`, set the global `UNIT`, and preserve `board.style` sizing and `gameInstance.render()`/`renderNext()` calls.

### Testing
- Ran `node --check tetris.js` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a49ac3d8848832db7c2478768ec79ce)