### PR TITLE
Maximize Tetris board scaling

### DIFF
--- a/tetris.css
+++ b/tetris.css
@@ -723,3 +723,40 @@ button:active {
     text-align: left;
 }
 #tetris-gameover .final-score { color: var(--accent); }
+
+/* --- Full viewport board scaling overrides --- */
+.container {
+    max-width: none !important;
+    width: 100vw;
+    height: 100vh;
+    padding: 8px;
+    box-sizing: border-box;
+}
+
+.main-grid {
+    grid-template-columns: 280px 1fr;
+    gap: 12px;
+}
+
+.game-section {
+    flex: 1;
+    min-height: 0;
+    height: 100%;
+}
+
+.game-board-wrapper {
+    flex: 1 1 auto;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    height: 100%;
+    padding: 6px;
+    background: transparent;
+    overflow: hidden;
+}
+
+.game-board {
+    border: 3px solid var(--win-dark);
+    box-shadow: 0 0 25px rgba(0, 0, 0, 0.6);
+}

--- a/tetris.js
+++ b/tetris.js
@@ -13,35 +13,49 @@ document.documentElement.style.setProperty('--area-y', ROWS);
 function syncBoardScale(gameInstance = null) {
   const wrapper = document.querySelector('.game-board-wrapper');
   const board = document.querySelector('.game-board');
+  const gameSection = document.querySelector('.game-section');
+
   if (!wrapper || !board) return;
 
-  const wrapperHeight = wrapper.clientHeight;
-  const wrapperWidth = wrapper.clientWidth;
+  // Forzar que el wrapper use TODO el espacio disponible.
+  wrapper.style.width = '100%';
+  wrapper.style.height = '100%';
+  wrapper.style.padding = '4px'; // Mínimo para el borde win98.
 
-  if (!wrapperHeight || !wrapperWidth) return;
+  // Asegurar que la sección también tenga una altura útil antes de medir.
+  if (gameSection) {
+    gameSection.style.height = '100%';
+    gameSection.style.minHeight = '0';
+  }
 
-  // Cálculo que prioriza llenar el espacio disponible
-  let dynamicUnit = Math.floor(Math.min(
-    wrapperHeight / ROWS,
-    wrapperWidth / COLS
-  ));
+  // Obtener dimensiones reales del wrapper después de layout.
+  const wrapperRect = wrapper.getBoundingClientRect();
+  const availableWidth = wrapperRect.width - 8; // Restar padding/bordes.
+  const availableHeight = wrapperRect.height - 8;
 
-  dynamicUnit = Math.max(1, dynamicUnit);
+  if (availableWidth <= 0 || availableHeight <= 0) return;
+
+  // Calcular unit para llenar al máximo manteniendo proporción.
+  const unitByWidth = Math.floor(availableWidth / COLS);
+  const unitByHeight = Math.floor(availableHeight / ROWS);
+
+  let dynamicUnit = Math.min(unitByWidth, unitByHeight);
+  dynamicUnit = Math.max(12, dynamicUnit); // Mínimo razonable para legibilidad.
 
   document.documentElement.style.setProperty('--unit', `${dynamicUnit}px`);
   UNIT = dynamicUnit;
 
-  // Forzar tamaño completo del tablero
-  board.style.height = `${ROWS * dynamicUnit}px`;
+  // Forzar tamaño exacto del tablero.
   board.style.width = `${COLS * dynamicUnit}px`;
-  board.style.maxHeight = 'none';
+  board.style.height = `${ROWS * dynamicUnit}px`;
   board.style.maxWidth = 'none';
+  board.style.maxHeight = 'none';
 
-  // Asegurar que la grilla de fondo también se expanda
+  // Asegurar que la grilla de fondo también coincida.
   const gameGrid = document.getElementById('gameGrid');
   if (gameGrid) {
-    gameGrid.style.height = `${ROWS * dynamicUnit}px`;
     gameGrid.style.width = `${COLS * dynamicUnit}px`;
+    gameGrid.style.height = `${ROWS * dynamicUnit}px`;
   }
 
   if (gameInstance) {
@@ -1392,5 +1406,12 @@ class TetrisGame {
 window.addEventListener('load', () => {
   syncBoardScale();
   const game = new TetrisGame();
-  window.addEventListener('resize', () => syncBoardScale(game));
+
+  window.addEventListener('resize', () => {
+    clearTimeout(window.resizeTimer);
+    window.resizeTimer = setTimeout(() => syncBoardScale(game), 50);
+  });
+
+  window.addEventListener('orientationchange', () => syncBoardScale(game));
+  document.addEventListener('fullscreenchange', () => syncBoardScale(game));
 });


### PR DESCRIPTION
### Motivation
- The game board was constrained by container max-width, paddings/borders, and rigid side-grid layout, preventing it from filling available space. 
- The goal is to make the grid occupy as much of the board wrapper/container as possible while keeping pieces legible and the layout stable. 

### Description
- Replaced `syncBoardScale()` in `tetris.js` to force the board wrapper to occupy available space, measure the real rendered size via `getBoundingClientRect()`, compute a proportional `dynamicUnit` (clamped with a minimum), set `--unit` and `UNIT`, and apply exact pixel dimensions to the board and `#gameGrid`. 
- Added safer scaling triggers in `tetris.js`: a debounced `resize` handler plus `orientationchange` and `fullscreenchange` listeners that call `syncBoardScale(game)`. 
- Appended CSS overrides to `tetris.css` to remove `max-width` constraints, make the root container full-viewport, relax the side-panel sizing (`.main-grid`), and make `.game-section`, `.game-board-wrapper`, and `.game-board` more flexible and visually prominent. 

### Testing
- Ran `node --check tetris.js` and the syntax check passed. 
- Ran `git diff --check` and no diff-check issues were reported. 
- Attempted to run headless browser-based visual tests but Playwright/Chromium was not available in the environment, so no automated visual rendering tests were executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a49c60a85d8832d87e41992dfef5f20)