### PR TITLE
Replace game board border with inset Win98 shadow

### DIFF
--- a/tetris.css
+++ b/tetris.css
@@ -757,6 +757,9 @@ button:active {
 }
 
 .game-board {
-    border: 3px solid var(--win-dark);
-    box-shadow: 0 0 25px rgba(0, 0, 0, 0.6);
+    box-shadow:
+        inset 3px 3px 0 0 var(--win-dark),
+        inset -3px -3px 0 0 var(--win-light),
+        inset 6px 6px 0 0 var(--win-shadow),
+        inset -6px -6px 0 0 var(--win-hl);
 }


### PR DESCRIPTION
### Motivation
- Unificar el estilo Win98 en el tablero reemplazando el borde sólido por una sombra interna multicapa para mantener consistencia con otros elementos y evitar el borde sobrescrito.

### Description
- En `tetris.css` se eliminó `border: 3px solid var(--win-dark)` y la sombra exterior y se añadió una `box-shadow` inset multicapa en la regla `.game-board` usando `var(--win-dark)`, `var(--win-light)`, `var(--win-shadow)` y `var(--win-hl)`.

### Testing
- Ejecuté `rg -n "inset 3px 3px|border: 3px solid var\(--win-dark\)" tetris.css` y confirmó la presencia de la nueva sombra y la ausencia del borde antiguo; el chequeo fue exitoso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a49c86cb490832dabde2305a07559bd)