### PR TITLE
Fix full-width Tetris board scaling

### DIFF
--- a/tetris.css
+++ b/tetris.css
@@ -724,24 +724,31 @@ button:active {
 }
 #tetris-gameover .final-score { color: var(--accent); }
 
-/* --- Full viewport board scaling overrides --- */
+/* === LAYOUT FULL-WIDTH === */
 .container {
     max-width: none !important;
-    width: 100vw;
-    height: 100vh;
+    width: 100vw !important;
+    height: 100vh !important;
     padding: 8px;
+    margin: 0;
     box-sizing: border-box;
 }
 
 .main-grid {
-    grid-template-columns: 280px 1fr;
+    grid-template-columns: 320px 1fr;
     gap: 12px;
+    height: calc(100vh - 16px);
+    align-items: stretch;
 }
 
 .game-section {
-    flex: 1;
-    min-height: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
     height: 100%;
+    min-height: 0;
+    background: transparent;
+    padding: 0;
 }
 
 .game-board-wrapper {
@@ -751,9 +758,10 @@ button:active {
     justify-content: center;
     width: 100%;
     height: 100%;
-    padding: 6px;
+    padding: 8px;
     background: transparent;
     overflow: hidden;
+    box-sizing: border-box;
 }
 
 .game-board {
@@ -762,4 +770,5 @@ button:active {
         inset -3px -3px 0 0 var(--win-light),
         inset 6px 6px 0 0 var(--win-shadow),
         inset -6px -6px 0 0 var(--win-hl);
+    border: none;
 }

--- a/tetris.js
+++ b/tetris.js
@@ -30,8 +30,8 @@ function syncBoardScale(gameInstance = null) {
 
   // Obtener dimensiones reales del wrapper después de layout.
   const wrapperRect = wrapper.getBoundingClientRect();
-  const availableWidth = wrapperRect.width - 8; // Restar padding/bordes.
-  const availableHeight = wrapperRect.height - 8;
+  const availableWidth = wrapperRect.width - 20; // Margen para padding y sombra Win98.
+  const availableHeight = wrapperRect.height - 20;
 
   if (availableWidth <= 0 || availableHeight <= 0) return;
 
@@ -1406,6 +1406,7 @@ class TetrisGame {
 window.addEventListener('load', () => {
   syncBoardScale();
   const game = new TetrisGame();
+  requestAnimationFrame(() => syncBoardScale(game));
 
   window.addEventListener('resize', () => {
     clearTimeout(window.resizeTimer);


### PR DESCRIPTION
### Motivation
- La grilla del juego aparecía demasiado pequeña y había un gran espacio vacío a la izquierda porque `.container` y `.main-grid` tenían restricciones de ancho/centrado que evitaban que el tablero aprovechara el ancho de la ventana. 
- Las piezas se veían pequeñas porque el cálculo del `unit` no estaba usando todo el espacio disponible ni descontaba la sombra/padding del wrapper.

### Description
- Actualiza el bloque de layout en `tetris.css` a `/* === LAYOUT FULL-WIDTH === */` y fuerza que `.container` use `width: 100vw !important` y `height: 100vh !important` con `margin: 0` para ocupar todo el viewport. 
- Reserva un panel izquierdo fijo cambiando `.main-grid` a `grid-template-columns: 320px 1fr`, añade `height: calc(100vh - 16px)` y `align-items: stretch` para que el tablero utilice el espacio restante. 
- Ajusta `.game-section`, `.game-board-wrapper` y `.game-board` para centrar el tablero, eliminar padding/overflow innecesario y quitar el `border` del `.game-board` para no restar espacio útil. 
- En `tetris.js` modifica el cálculo en `syncBoardScale` para descontar más margen (`availableWidth/Height = wrapperRect - 20`) y añade una re-sincronización post-inicialización con `requestAnimationFrame(() => syncBoardScale(game))` para recalcular la escala después de que el layout se estabilice. 

### Testing
- Ejecutado `git diff --check` y pasó sin errores. 
- Ejecutado `node --check tetris.js` y no reportó errores de sintaxis. 
- Ejecutado `node --check bot.worker.js` y no reportó errores de sintaxis.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a49ca3fd1c8832da72a004144a44e78)