### PR TITLE
Fix game section full-width layout

### DIFF
--- a/tetris.css
+++ b/tetris.css
@@ -630,14 +630,18 @@ button:active {
 
 .tetris-window {
     display: flex;
+    flex: 1 1 auto;
     flex-direction: column;
-    width: max-content;
+    width: 100%;
+    min-width: 0;
     height: 100%;
     max-height: 100%;
 }
 .tetris-window .win98-client {
     display: flex;
-    flex: 1;
+    flex: 1 1 auto;
+    width: 100%;
+    min-width: 0;
     min-height: 0;
 }
 .game-board-wrapper { background: transparent; }
@@ -735,16 +739,20 @@ button:active {
 }
 
 .main-grid {
-    grid-template-columns: 320px 1fr;
+    grid-template-columns: 320px minmax(0, 1fr);
     gap: 12px;
     height: calc(100vh - 16px);
     align-items: stretch;
+    width: 100%;
+    min-width: 0;
 }
 
 .game-section {
     display: flex;
-    align-items: center;
-    justify-content: center;
+    align-items: stretch;
+    justify-content: stretch;
+    width: 100%;
+    min-width: 0;
     height: 100%;
     min-height: 0;
     background: transparent;


### PR DESCRIPTION
### Motivation
- The right-side game column was not taking the full available width so the Tetris board became constrained and scaled down incorrectly.
- The root cause was the layout using `1fr` and a Tetris window sized with `width: max-content`, which prevents the column from shrinking/growing predictably and blocks accurate measurement by the board scaler.
- The goal is to let the right column shrink/expand reliably and make the Tetris window and its client fill the available space so `syncBoardScale` can compute a correct `--unit`.

### Description
- Replace `grid-template-columns: 320px 1fr;` with `grid-template-columns: 320px minmax(0, 1fr);` to allow the right column to shrink below intrinsic content size while remaining flexible.
- Update `.tetris-window` to `flex: 1 1 auto`, `width: 100%`, and `min-width: 0` so the window no longer forces `max-content` sizing and can fill the grid cell.
- Update `.tetris-window .win98-client` to `flex: 1 1 auto`, `width: 100%`, and `min-width: 0` to ensure the client area also stretches and provides correct measurement space for the board wrapper.
- Adjust `.main-grid` and `.game-section` to include `width: 100%`, `min-width: 0`, and use `align-items: stretch` / `justify-content: stretch` so the game-section and board wrapper occupy the full column space.
- File modified: `tetris.css` (layout-related rules as listed above).

### Testing
- Ran `git diff --check` to validate whitespace and diff issues and it passed.
- Executed the included Python static assertions that verify the CSS layout tokens (checks for `minmax(0, 1fr)`, `width: 100%`, `min-width: 0`, and the `.tetris-window`/client rules) and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a49cde18678832da21e12a71918f6ca)