### PR TITLE
Match game window width to left panel

### DIFF
--- a/tetris.css
+++ b/tetris.css
@@ -29,6 +29,7 @@
     --disabled:     #808080;
     --grid-line:    rgba(0, 0, 0, 0.12);
     --desktop:      #008080;
+    --panel-window-width: 320px;
 
     /* Alias de compatibilidad */
     --bg:           var(--desktop);
@@ -739,10 +740,11 @@ button:active {
 }
 
 .main-grid {
-    grid-template-columns: 320px minmax(0, 1fr);
+    grid-template-columns: var(--panel-window-width) var(--panel-window-width);
     gap: 12px;
     height: calc(100vh - 16px);
     align-items: stretch;
+    justify-content: center;
     width: 100%;
     min-width: 0;
 }
@@ -751,7 +753,7 @@ button:active {
     display: flex;
     align-items: stretch;
     justify-content: stretch;
-    width: 100%;
+    width: var(--panel-window-width);
     min-width: 0;
     height: 100%;
     min-height: 0;


### PR DESCRIPTION
### Motivation
- Ensure the game board and grid never expand wider than the left control panel so the two windows share the same fixed width and remain visually centered.

### Description
- Added a shared CSS variable `--panel-window-width: 320px` and updated `.main-grid` to use `grid-template-columns: var(--panel-window-width) var(--panel-window-width)`.
- Constrained the game column by setting `.game-section { width: var(--panel-window-width); }` and added `justify-content: center` to keep the pair of panels centered.

### Testing
- Ran `git diff --check` which reported no problems.
- Served the app and fetched `http://127.0.0.1:8000/index.html` with `curl -I`, receiving an HTTP 200 response indicating assets are served successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a49cf9a8d84832d951e4ee3a140e7b5)