### PR TITLE
Add split-screen Player vs CPU layout and refactor Tetris into multi-instance, responsive components

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,6 +12,8 @@
 
 <body>
     <div class="container">
+        <div class="versus-grid">
+        <section class="game-instance player-instance" data-player="P1">
         <div class="main-grid">
             <div class="control-panel">
                 <section class="win98-window stats-window">
@@ -23,15 +25,15 @@
                         <div class="stats-grid">
                             <div class="stat-card highlight">
                                 <label>Score</label>
-                                <div class="value win98-inset" id="tetris-stats-score">0</div>
+                                <div class="value win98-inset tetris-stats-score">0</div>
                             </div>
                             <div class="stat-card">
                                 <label>Lines</label>
-                                <div class="value win98-inset" id="tetris-stats-lines">0</div>
+                                <div class="value win98-inset tetris-stats-lines">0</div>
                             </div>
                             <div class="timer-box">
                                 <label>Time</label>
-                                <div class="value win98-inset" id="tetris-stats-time">0:00</div>
+                                <div class="value win98-inset tetris-stats-time">0:00</div>
                             </div>
                         </div>
                     </div>
@@ -44,18 +46,18 @@
                     </div>
                     <div class="win98-client control-stack">
                         <div class="controls">
-                            <button class="btn-primary" id="playBtn">▶ Play</button>
-                            <button class="btn-secondary" id="newGameBtn">↻ New Game</button>
+                            <button class="btn-primary playBtn">▶ Play</button>
+                            <button class="btn-secondary newGameBtn">↻ New Game</button>
                         </div>
                         <div class="mode-switches">
                             <div class="switch-group">
-                                <label for="iaAssistToggle">IA-ASSIST</label>
-                                <button type="button" class="switch" id="iaAssistToggle"></button>
+                                <label>IA-ASSIST</label>
+                                <button type="button" class="switch iaAssistToggle"></button>
                             </div>
                         </div>
-                        <div class="bot-settings" id="botSettings">
+                        <div class="bot-settings botSettings">
                             <div class="bot-settings-header">🤖 IA MODE</div>
-                            <div id="bot-strategy-indicator" class="bot-strategy balanced win98-inset">ANALIZANDO...</div>
+                            <div class="bot-strategy balanced win98-inset bot-strategy-indicator">ANALIZANDO...</div>
                         </div>
                     </div>
                 </section>
@@ -66,7 +68,7 @@
                         <span class="win-btns"><button>_</button><button>▢</button><button>✕</button></span>
                     </div>
                     <div class="win98-client">
-                        <div class="next-piece-box win98-inset" id="tetris-nextpuzzle"></div>
+                        <div class="next-piece-box win98-inset tetris-nextpuzzle"></div>
                     </div>
                 </section>
 
@@ -76,7 +78,7 @@
                         <span class="win-btns"><button>_</button><button>▢</button><button>✕</button></span>
                     </div>
                     <div class="win98-client">
-                        <div id="wall-logs" class="log-content win98-inset">
+                        <div class="log-content win98-inset wall-logs">
                             <div class="log-entry placeholder">Esperando datos...</div>
                         </div>
                     </div>
@@ -86,27 +88,124 @@
             <div class="game-section">
                 <section class="win98-window tetris-window">
                     <div class="win98-titlebar">
-                        <span class="title">🕹️ Tetris.exe v8.5</span>
+                        <span class="title">🕹️ Tetris.exe v2.1 — P1</span>
                         <span class="win-btns"><button>_</button><button>▢</button><button>✕</button></span>
                     </div>
                     <div class="win98-client">
                         <div class="game-board-wrapper">
                             <div class="game-board win98-inset">
-                                <div class="game-grid" id="gameGrid"></div>
-                                <div id="tetris-area"></div>
-                                <div class="game-message idle" id="gameMessage">
+                                <div class="game-grid gameGrid"></div>
+                                <div class="tetris-area"></div>
+                                <div class="game-message idle gameMessage">
                                     <h2>PRESS START</h2>
                                     <p>Ready to play?</p>
                                 </div>
                             </div>
                         </div>
                     </div>
-                    <div class="win98-statusbar" id="mode-status">MODO: MANUAL</div>
+                    <div class="win98-statusbar mode-status">MODO: MANUAL</div>
                 </section>
             </div>
         </div>
+        <div class="tetris-gameover" style="display:none;"></div>
+        </section>
+        <section class="game-instance cpu-instance" data-player="CPU">
+        <div class="main-grid">
+            <div class="control-panel">
+                <section class="win98-window stats-window">
+                    <div class="win98-titlebar">
+                        <span class="title">📊 Estadísticas</span>
+                        <span class="win-btns"><button>_</button><button>▢</button><button>✕</button></span>
+                    </div>
+                    <div class="win98-client">
+                        <div class="stats-grid">
+                            <div class="stat-card highlight">
+                                <label>Score</label>
+                                <div class="value win98-inset tetris-stats-score">0</div>
+                            </div>
+                            <div class="stat-card">
+                                <label>Lines</label>
+                                <div class="value win98-inset tetris-stats-lines">0</div>
+                            </div>
+                            <div class="timer-box">
+                                <label>Time</label>
+                                <div class="value win98-inset tetris-stats-time">0:00</div>
+                            </div>
+                        </div>
+                    </div>
+                </section>
 
-        <div id="tetris-gameover" style="display:none;"></div>
+                <section class="win98-window control-window">
+                    <div class="win98-titlebar">
+                        <span class="title">🎮 Control IA</span>
+                        <span class="win-btns"><button>_</button><button>▢</button><button>✕</button></span>
+                    </div>
+                    <div class="win98-client control-stack">
+                        <div class="controls">
+                            <button class="btn-primary playBtn">▶ Play</button>
+                            <button class="btn-secondary newGameBtn">↻ New Game</button>
+                        </div>
+                        <div class="mode-switches">
+                            <div class="switch-group">
+                                <label>IA-ASSIST</label>
+                                <button type="button" class="switch iaAssistToggle"></button>
+                            </div>
+                        </div>
+                        <div class="bot-settings botSettings">
+                            <div class="bot-settings-header">🤖 IA MODE</div>
+                            <div class="bot-strategy balanced win98-inset bot-strategy-indicator">ANALIZANDO...</div>
+                        </div>
+                    </div>
+                </section>
+
+                <section class="win98-window inline-next-piece">
+                    <div class="win98-titlebar">
+                        <span class="title">🧩 Próxima Pieza</span>
+                        <span class="win-btns"><button>_</button><button>▢</button><button>✕</button></span>
+                    </div>
+                    <div class="win98-client">
+                        <div class="next-piece-box win98-inset tetris-nextpuzzle"></div>
+                    </div>
+                </section>
+
+                <section class="win98-window log-panel">
+                    <div class="win98-titlebar">
+                        <span class="title">🧱 Wall Integrity</span>
+                        <span class="win-btns"><button>_</button><button>▢</button><button>✕</button></span>
+                    </div>
+                    <div class="win98-client">
+                        <div class="log-content win98-inset wall-logs">
+                            <div class="log-entry placeholder">Esperando datos...</div>
+                        </div>
+                    </div>
+                </section>
+            </div>
+
+            <div class="game-section">
+                <section class="win98-window tetris-window">
+                    <div class="win98-titlebar">
+                        <span class="title">🕹️ Tetris.exe v2.1 — CPU</span>
+                        <span class="win-btns"><button>_</button><button>▢</button><button>✕</button></span>
+                    </div>
+                    <div class="win98-client">
+                        <div class="game-board-wrapper">
+                            <div class="game-board win98-inset">
+                                <div class="game-grid gameGrid"></div>
+                                <div class="tetris-area"></div>
+                                <div class="game-message idle gameMessage">
+                                    <h2>PRESS START</h2>
+                                    <p>Ready to play?</p>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="win98-statusbar mode-status">MODO: MANUAL</div>
+                </section>
+            </div>
+        </div>
+        <div class="tetris-gameover" style="display:none;"></div>
+        </section>
+        </div>
     </div>
 </body>
 

--- a/tetris.css
+++ b/tetris.css
@@ -1,10 +1,6 @@
 @import url('https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap');
 
 :root {
-    --unit: 20px;
-    --area-x: 12;
-    --area-y: 22;
-
     /* Superficie Win98 */
     --win-face:     #c0c0c0;
     --win-hl:       #ffffff;
@@ -68,6 +64,34 @@ body {
     gap: 10px;
 }
 
+.versus-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 12px;
+    width: 100%;
+    height: 100%;
+    min-height: 0;
+}
+
+.game-instance {
+    --unit: 20px;
+    --area-x: 12;
+    --area-y: 22;
+    position: relative;
+    min-width: 0;
+    min-height: 0;
+}
+
+.game-instance .main-grid {
+    grid-template-columns: minmax(150px, 0.8fr) minmax(240px, 1fr);
+    height: 100%;
+}
+
+.cpu-instance .controls,
+.cpu-instance .mode-switches {
+    display: none;
+}
+
 /* --- ESTÉTICA RETRO / ARCADE (Reemplaza Win95) --- */
 
 .header {
@@ -91,7 +115,7 @@ body {
     color: var(--text-dim);
 }
 
-#mode-status {
+.mode-status {
     color: var(--accent);
     font-size: 0.7rem;
     margin-top: 5px;
@@ -252,13 +276,13 @@ button:active {
     background-size: var(--unit) var(--unit);
 }
 
-#gameGrid,
-#tetris-area {
+.game-grid,
+.tetris-area {
     width: 100% !important;
     height: 100% !important;
 }
 
-#tetris-area {
+.tetris-area {
     background: transparent;
     position: absolute !important;
     inset: 0 !important;
@@ -266,8 +290,8 @@ button:active {
 }
 
 /* SPRITES DE LOS BLOQUES */
-#tetris-area > div,
-#tetris-nextpuzzle > div,
+.tetris-area > div,
+.tetris-nextpuzzle > div,
 .active-block {
     width: var(--unit);
     height: var(--unit);
@@ -415,7 +439,7 @@ button:active {
 .placeholder { color: var(--text-dim); font-style: italic; border: none; }
 
 /* Game Over Modal */
-#tetris-gameover {
+.tetris-gameover {
     position: absolute;
     top: 50%;
     left: 50%;
@@ -433,14 +457,14 @@ button:active {
     text-align: center;
 }
 
-#tetris-gameover h2 {
+.tetris-gameover h2 {
     color: var(--danger);
     animation: blink-text 0.8s infinite;
 }
-#tetris-gameover .final-score { color: var(--accent); }
+.tetris-gameover .final-score { color: var(--accent); }
 
 /* Bot Status */
-#bot-strategy-indicator {
+.bot-strategy-indicator {
     background: var(--panel-2);
     border: 1px solid #ccc;
     color: var(--log);
@@ -683,7 +707,7 @@ button:active {
 .log-entry.solid { border-color: var(--log); color: var(--log); }
 .log-entry.broken { border-color: var(--danger); color: var(--danger); }
 
-#bot-strategy-indicator {
+.bot-strategy-indicator {
     border: none;
     color: var(--log);
     padding: 6px 8px;
@@ -705,7 +729,7 @@ button:active {
     text-align: center;
 }
 
-#tetris-gameover {
+.tetris-gameover {
     border: none;
     padding: 22px 12px 12px;
     background: var(--win-face);
@@ -715,7 +739,7 @@ button:active {
         inset -2px -2px 0 0 var(--win-shadow),
         inset  2px  2px 0 0 var(--win-light);
 }
-#tetris-gameover::before {
+.tetris-gameover::before {
     content: 'Game Over';
     position: absolute;
     top: 2px;
@@ -727,7 +751,7 @@ button:active {
     font-size: 0.45rem;
     text-align: left;
 }
-#tetris-gameover .final-score { color: var(--accent); }
+.tetris-gameover .final-score { color: var(--accent); }
 
 /* === LAYOUT FULL-WIDTH === */
 .container {

--- a/tetris.js
+++ b/tetris.js
@@ -2,18 +2,19 @@
 
 const COLS = 12;
 const ROWS = 22;
-let UNIT = 20; // Coincide con --unit en CSS y se ajusta al alto del contenedor
 
 const PIECE_TYPES = ['I', 'O', 'T', 'S', 'Z', 'J', 'L'];
 const BLOCK_CLASSES = ['block0', 'block1', 'block2', 'block3', 'block4', 'block5', 'block6'];
 
-document.documentElement.style.setProperty('--area-x', COLS);
-document.documentElement.style.setProperty('--area-y', ROWS);
+function syncBoardScale(gameInstance) {
+  if (!(gameInstance instanceof TetrisGame)) {
+    console.error('[AGENT][syncBoardScale] Fast-Fail: instancia de juego invalida.');
+    return;
+  }
 
-function syncBoardScale(gameInstance = null) {
-  const wrapper = document.querySelector('.game-board-wrapper');
-  const board = document.querySelector('.game-board');
-  const gameSection = document.querySelector('.game-section');
+  const wrapper = gameInstance.$('.game-board-wrapper');
+  const board = gameInstance.$('.game-board');
+  const gameSection = gameInstance.$('.game-section');
 
   if (!wrapper || !board) return;
 
@@ -42,8 +43,8 @@ function syncBoardScale(gameInstance = null) {
   let dynamicUnit = Math.min(unitByWidth, unitByHeight);
   dynamicUnit = Math.max(12, dynamicUnit); // Mínimo razonable para legibilidad.
 
-  document.documentElement.style.setProperty('--unit', `${dynamicUnit}px`);
-  UNIT = dynamicUnit;
+  gameInstance.UNIT = dynamicUnit;
+  gameInstance.root.style.setProperty('--unit', `${dynamicUnit}px`);
 
   // Forzar tamaño exacto del tablero.
   board.style.width = `${COLS * dynamicUnit}px`;
@@ -52,16 +53,14 @@ function syncBoardScale(gameInstance = null) {
   board.style.maxHeight = 'none';
 
   // Asegurar que la grilla de fondo también coincida.
-  const gameGrid = document.getElementById('gameGrid');
+  const gameGrid = gameInstance.$('.game-grid');
   if (gameGrid) {
     gameGrid.style.width = `${COLS * dynamicUnit}px`;
     gameGrid.style.height = `${ROWS * dynamicUnit}px`;
   }
 
-  if (gameInstance) {
-    gameInstance.render();
-    gameInstance.renderNext();
-  }
+  gameInstance.render();
+  gameInstance.renderNext();
 }
 
 const TETROMINOS = {
@@ -202,12 +201,42 @@ class GeometricEvaluator {
 }
 
 class TetrisGame {
-  constructor() {
+  constructor(root, options = {}) {
+    if (!root) throw new Error('[AGENT] TetrisGame requiere un root element.');
+    this.root = root;
+    this.isCPU = options.isCPU ?? false;
+    this.playerName = options.playerName ?? 'P1';
+    this.onAttack = options.onAttack ?? null;
+    this.onDefeat = options.onDefeat ?? null;
+    this.UNIT = 20;
+    this.garbageQueue = 0;
+    this.root.style.setProperty('--area-x', COLS);
+    this.root.style.setProperty('--area-y', ROWS);
+    this.root.style.setProperty('--unit', `${this.UNIT}px`);
+
+    this.els = {
+      area: this.$('.tetris-area'),
+      nextBox: this.$('.tetris-nextpuzzle'),
+      indicator: this.$('.bot-strategy-indicator'),
+      timer: this.$('.tetris-stats-time'),
+      score: this.$('.tetris-stats-score'),
+      lines: this.$('.tetris-stats-lines'),
+      status: this.$('.mode-status'),
+      wallLogs: this.$('.wall-logs'),
+      playBtn: this.$('.playBtn'),
+      newGameBtn: this.$('.newGameBtn'),
+      iaAssistToggle: this.$('.iaAssistToggle'),
+      gameMessage: this.$('.gameMessage'),
+      gameOver: this.$('.tetris-gameover')
+    };
+    if (!this.els.area || !this.els.nextBox) {
+      throw new Error(`[AGENT][${this.playerName}] DOM de tablero incompleto.`);
+    }
     this.board = Array.from({length: ROWS}, () => Array(COLS).fill(-1));
-    this.area = document.getElementById('tetris-area');
-    this.nextBox = document.getElementById('tetris-nextpuzzle');
-    this.indicator = document.getElementById('bot-strategy-indicator');
-    this.timerDisplay = document.getElementById('tetris-stats-time');
+    this.area = this.els.area;
+    this.nextBox = this.els.nextBox;
+    this.indicator = this.els.indicator;
+    this.timerDisplay = this.els.timer;
     this.activeBlocksDOM = [];
     this.initActiveBlocks();
 
@@ -267,6 +296,10 @@ class TetrisGame {
 
     this.bindEvents();
     this.loop();
+  }
+
+  $(sel) {
+    return this.root.querySelector(sel);
   }
 
   initActiveBlocks() {
@@ -351,11 +384,16 @@ class TetrisGame {
   }
 
   bindEvents() {
-    document.getElementById('playBtn').onclick = () => this.togglePause();
-    document.getElementById('newGameBtn').onclick = () => this.reset();
-    document.getElementById('iaAssistToggle').onclick = () => {
+    if (this.isCPU) return;
+    if (!this.els.playBtn || !this.els.newGameBtn || !this.els.iaAssistToggle) {
+      console.error(`[AGENT][${this.playerName}] Fast-Fail: controles incompletos.`);
+      return;
+    }
+    this.els.playBtn.onclick = () => this.togglePause();
+    this.els.newGameBtn.onclick = () => this.reset();
+    this.els.iaAssistToggle.onclick = () => {
       this.iaAssist = !this.iaAssist;
-      document.getElementById('iaAssistToggle').classList.toggle('active', this.iaAssist);
+      this.els.iaAssistToggle.classList.toggle('active', this.iaAssist);
       
       // --- CORRECCIÓN DE LIMPIEZA ---
       this.pendingBotRequestId = null;
@@ -377,7 +415,7 @@ class TetrisGame {
       this.fallAccumulator = 0;
       this.dasTimer = 0;
       this.keys = { left: false, right: false, down: false };
-      const statusEl = document.getElementById('mode-status');
+      const statusEl = this.els.status;
       if (statusEl) {
         statusEl.textContent = this.iaAssist ? 'MODO: INICIANDO...' : 'MODO: MANUAL';
       }
@@ -506,8 +544,8 @@ class TetrisGame {
   createBlock(typeId, x, y, extraClass = '') {
     const div = document.createElement('div');
     div.className = BLOCK_CLASSES[typeId] + ' ' + extraClass;
-    div.style.left = `${x * UNIT}px`;
-    div.style.top = `${y * UNIT}px`;
+    div.style.left = `${x * this.UNIT}px`;
+    div.style.top = `${y * this.UNIT}px`;
     this.area.appendChild(div);
   }
 
@@ -531,8 +569,8 @@ class TetrisGame {
         if (val && blockIndex < 4) {
           const block = this.activeBlocksDOM[blockIndex];
           block.className = `active-block ${BLOCK_CLASSES[this.current.typeId]} bot-controlled`;
-          block.style.left = `${(this.current.x + dx) * UNIT}px`;
-          block.style.top = `${(this.current.y + dy) * UNIT}px`;
+          block.style.left = `${(this.current.x + dx) * this.UNIT}px`;
+          block.style.top = `${(this.current.y + dy) * this.UNIT}px`;
           block.style.display = 'block';
           blockIndex++;
         }
@@ -569,8 +607,8 @@ class TetrisGame {
         if (val) {
           const div = document.createElement('div');
           div.className = BLOCK_CLASSES[this.next.typeId];
-          div.style.left = `${(dx + offsetX) * UNIT}px`;
-          div.style.top = `${(dy + offsetY) * UNIT}px`;
+          div.style.left = `${(dx + offsetX) * this.UNIT}px`;
+          div.style.top = `${(dy + offsetY) * this.UNIT}px`;
           this.nextBox.appendChild(div);
         }
       });
@@ -620,7 +658,7 @@ class TetrisGame {
     this.botMode = mode || this.botMode;
 
     if (strategy) {
-      const statusEl = document.getElementById('mode-status');
+      const statusEl = this.els.status;
       if (statusEl) statusEl.textContent = `MODO: ${strategy}`;
     }
 
@@ -648,7 +686,7 @@ class TetrisGame {
 
     this.lastWallsIntactState = isIntact;
     this.lastWellColumn = wellCol;
-    const container = document.getElementById('wall-logs');
+    const container = this.els.wallLogs;
     if (!container) return;
 
     const placeholder = container.querySelector('.placeholder');
@@ -1193,8 +1231,8 @@ class TetrisGame {
     this.isAnimating = false;
     this.rowsToClear = null;
 
-    document.getElementById('tetris-stats-lines').textContent = this.lines;
-    document.getElementById('tetris-stats-score').textContent = this.score;
+    if (this.els.lines) this.els.lines.textContent = this.lines;
+    if (this.els.score) this.els.score.textContent = this.score;
 
     this.ghost = null;
     this.botPlan = null;
@@ -1216,7 +1254,7 @@ class TetrisGame {
     this.isGameOverAnimating = true;
     this.stopTimer();
     this.hideActiveBlocks();
-    const btn = document.getElementById('playBtn');
+    const btn = this.els.playBtn;
     if (btn) btn.textContent = '▶ Play';
 
     this.runGameOverDestruction();
@@ -1261,22 +1299,22 @@ class TetrisGame {
   togglePause() {
     if (this.isGameOverAnimating) return;
     this.paused = !this.paused;
-    const btn = document.getElementById('playBtn'); // Referencia al botón
+    const btn = this.els.playBtn;
 
     if (this.paused) {
-      document.getElementById('gameMessage')?.style.setProperty('display', 'block');
+      this.els.gameMessage?.style.setProperty('display', 'block');
       this.pauseTimer();
       if (btn) btn.textContent = '▶ Play'; // Cambio visual a Play
     } else if (!this.gameOver) {
-      document.getElementById('gameMessage')?.style.setProperty('display', 'none');
+      this.els.gameMessage?.style.setProperty('display', 'none');
       this.resumeTimer();
       if (btn) btn.textContent = '⏸ Pause'; // Cambio visual a Pause
     }
   }
 
   showGameOverScreen() {
-    document.getElementById('gameMessage')?.style.setProperty('display', 'block');
-    const el = document.getElementById('tetris-gameover');
+    this.els.gameMessage?.style.setProperty('display', 'block');
+    const el = this.els.gameOver;
     if (!el) return;
 
     el.innerHTML = `
@@ -1284,20 +1322,20 @@ class TetrisGame {
         <p>SCORE FINAL</p>
         <div class="final-score">${this.score}</div>
         <p>Lines: ${this.lines}</p>
-        <button class="btn-primary" id="retryBtn">TRY AGAIN</button>
+        <button class="btn-primary retryBtn">TRY AGAIN</button>
     `;
     
     // Activar botón de reintento
-    const retryBtn = el.querySelector('#retryBtn');
+    const retryBtn = el.querySelector('.retryBtn');
     retryBtn.onclick = () => this.reset();
 
     el.style.display = 'flex';
   }
 
   reset() {
-    const goScreen = document.getElementById('tetris-gameover');
+    const goScreen = this.els.gameOver;
     if (goScreen) goScreen.style.display = 'none';
-    document.getElementById('gameMessage')?.style.setProperty('display', 'block');
+    this.els.gameMessage?.style.setProperty('display', 'block');
     this.gameOver = false;
     this.isGameOverAnimating = false;
     this.board = Array.from({length: ROWS}, () => Array(COLS).fill(-1));
@@ -1308,7 +1346,7 @@ class TetrisGame {
     this.paused = true;
     this.isAnimating = false;
     this.rowsToClear = null;
-    const btn = document.getElementById('playBtn');
+    const btn = this.els.playBtn;
     if (btn) btn.textContent = '▶ Play';
     this.score = 0;
     this.lines = 0;
@@ -1326,8 +1364,8 @@ class TetrisGame {
     this.botMode = null;
     this.stopTimer();
     this.updateTimerDisplay();
-    document.getElementById('tetris-stats-score').textContent = this.score;
-    document.getElementById('tetris-stats-lines').textContent = this.lines;
+    if (this.els.score) this.els.score.textContent = this.score;
+    if (this.els.lines) this.els.lines.textContent = this.lines;
     this.render();
     this.renderNext();
     this.updateIndicator();
@@ -1404,15 +1442,24 @@ class TetrisGame {
 }
 
 window.addEventListener('load', () => {
-  syncBoardScale();
-  const game = new TetrisGame();
-  requestAnimationFrame(() => syncBoardScale(game));
+  const playerRoot = document.querySelector('.player-instance');
+  const cpuRoot = document.querySelector('.cpu-instance');
+  if (!playerRoot || !cpuRoot) {
+    console.error('[AGENT][bootstrap] Fast-Fail: faltan roots de jugador o CPU.');
+    return;
+  }
+
+  const games = [
+    new TetrisGame(playerRoot, { playerName: 'P1' }),
+    new TetrisGame(cpuRoot, { playerName: 'CPU', isCPU: true })
+  ];
+  requestAnimationFrame(() => games.forEach(syncBoardScale));
 
   window.addEventListener('resize', () => {
     clearTimeout(window.resizeTimer);
-    window.resizeTimer = setTimeout(() => syncBoardScale(game), 50);
+    window.resizeTimer = setTimeout(() => games.forEach(syncBoardScale), 50);
   });
 
-  window.addEventListener('orientationchange', () => syncBoardScale(game));
-  document.addEventListener('fullscreenchange', () => syncBoardScale(game));
+  window.addEventListener('orientationchange', () => games.forEach(syncBoardScale));
+  document.addEventListener('fullscreenchange', () => games.forEach(syncBoardScale));
 });


### PR DESCRIPTION
### Motivation
- Enable running two independent Tetris instances (Player and CPU) side-by-side with a responsive layout for versus/playback scenarios. 
- Move away from single-global DOM/ID coupling so each game instance can maintain its own state, UI and scaling. 
- Improve layout/responsiveness and hide control UI for CPU instance to avoid accidental interaction. 

### Description
- Split `index.html` into two `.game-instance` sections (`.player-instance` and `.cpu-instance`) and converted several element `id`s to class-based selectors (e.g. `#playBtn` → `.playBtn`, `#tetris-nextpuzzle` → `.tetris-nextpuzzle`, `#tetris-stats-score` → `.tetris-stats-score`, `#tetris-gameover` → `.tetris-gameover`, etc.) to allow multiple independent DOM roots. 
- Added `.versus-grid`, `.game-instance` and related responsive CSS and instance-specific rules in `tetris.css`, and hid control UI on the CPU instance via `.cpu-instance .controls { display: none; }`. 
- Refactored `tetris.js` to support instance-based games: `TetrisGame` now accepts a `root` DOM element and `options` (e.g. `isCPU`, `playerName`), stores instance-scoped elements in `this.els`, and uses `this.UNIT` instead of a single global `UNIT`. 
- Replaced global helper calls with instance helpers: added `$(sel)` method, changed `syncBoardScale(gameInstance)` to accept `TetrisGame` instances and resize the specific root, and updated rendering/DOM updates to reference `this.els` instead of `document.getElementById`. 
- Bootstrapped two instances on `window.load` (`P1` and `CPU`), wired resize/orientation/fullscreen handlers to call `syncBoardScale` for each instance, and prevented binding controls for CPU instances. 
- Adjusted game UI behaviors to use class-based retry/play buttons and updated game-over, indicator, stats and log update logic to operate per-instance. 

### Testing
- No automated tests were run against these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a66668440e8832d8f5ef961c9d62fbc)