### PR TITLE
Fix versus runtime feedback

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,6 +20,7 @@
                     </div>
                     <div class="win98-client">
                         <div class="game-board-wrapper">
+                            <div class="garbage-meter" role="status" aria-label="CPU pending garbage"></div>
                             <div class="game-board win98-inset">
                                 <div class="game-grid"></div>
                                 <div class="tetris-area"></div>
@@ -131,6 +132,7 @@
                     </div>
                     <div class="win98-client">
                         <div class="game-board-wrapper">
+                            <div class="garbage-meter" role="status" aria-label="Player pending garbage"></div>
                             <div class="game-board win98-inset">
                                 <div class="game-grid"></div>
                                 <div class="tetris-area"></div>

--- a/tetris.css
+++ b/tetris.css
@@ -223,6 +223,7 @@ button:active {
     display: flex;
     align-items: center;
     justify-content: center;
+    gap: 6px;
     width: 100%;
     height: 100%;
     min-height: 0;
@@ -800,6 +801,29 @@ button:active {
     padding: 8px;
     background: transparent;
     overflow: hidden;
+    box-sizing: border-box;
+}
+
+.garbage-meter {
+    display: flex;
+    flex: 0 0 var(--unit);
+    flex-direction: column-reverse;
+    align-self: center;
+    width: var(--unit);
+    height: calc(var(--area-y) * var(--unit));
+    overflow: hidden;
+    background: rgba(64, 0, 0, 0.45);
+    border: 2px inset var(--win-light);
+    box-sizing: border-box;
+}
+
+.garbage-meter-line {
+    flex: 0 0 var(--unit);
+    width: 100%;
+    height: var(--unit);
+    border-top: 1px solid #ff8080;
+    border-bottom: 1px solid #500;
+    background: linear-gradient(90deg, #820000, #f22 55%, #820000);
     box-sizing: border-box;
 }
 

--- a/tetris.js
+++ b/tetris.js
@@ -3,6 +3,7 @@
 const COLS = 12;
 const ROWS = 22;
 const GARBAGE_ID = 7;
+const ATTACK_TABLE = [0, 1, 2, 4, 6];
 
 const PIECE_TYPES = ['I', 'O', 'T', 'S', 'Z', 'J', 'L'];
 const BLOCK_CLASSES = ['block0', 'block1', 'block2', 'block3', 'block4', 'block5', 'block6', 'block-garbage'];
@@ -44,7 +45,7 @@ function syncBoardScale(gameInstance, scaleFactor = 1) {
   if (availableWidth <= 0 || availableHeight <= 0) return;
 
   // Calcular unit para llenar al máximo manteniendo proporción.
-  const unitByWidth = Math.floor(availableWidth / COLS);
+  const unitByWidth = Math.floor((availableWidth - 6) / (COLS + 1));
   const unitByHeight = Math.floor(availableHeight / ROWS);
 
   let dynamicUnit = Math.floor(Math.min(unitByWidth, unitByHeight) * scaleFactor);
@@ -236,7 +237,8 @@ class TetrisGame {
       newGameBtn: this.$('.newGameBtn'),
       iaAssistToggle: this.$('.iaAssistToggle'),
       gameMessage: this.$('.gameMessage'),
-      gameOver: this.$('.tetris-gameover')
+      gameOver: this.$('.tetris-gameover'),
+      garbageMeter: this.$('.garbage-meter')
     };
     if (!this.els.area || !this.els.nextBox) {
       throw new Error(`[AGENT][${this.playerName}] DOM de tablero incompleto.`);
@@ -303,6 +305,7 @@ class TetrisGame {
     this.renderNext();
     this.updateIndicator();
     this.updateTimerDisplay();
+    this.updateGarbageMeter();
 
   }
 
@@ -429,7 +432,7 @@ class TetrisGame {
       event.preventDefault();
     }
 
-    if (this.paused || this.gameOver || this.isAnimating || this.isGameOverAnimating) return;
+    if (this.paused || this.gameOver || this.iaAssist || this.isAnimating || this.isGameOverAnimating) return;
     const pieceReady = this.current && this.areTimer === 0;
 
     switch (event.key) {
@@ -593,6 +596,7 @@ class TetrisGame {
     const h = matrix.length;
     const COLS_BOX = 6;
     const ROWS_BOX = 5;
+    const boxUnit = this.nextBox.clientWidth / COLS_BOX;
     const offsetX = (COLS_BOX - w) / 2;
     const offsetY = (ROWS_BOX - h) / 2;
     matrix.forEach((row, dy) => {
@@ -600,8 +604,8 @@ class TetrisGame {
         if (val) {
           const div = document.createElement('div');
           div.className = BLOCK_CLASSES[this.next.typeId];
-          div.style.left = `${(dx + offsetX) * this.UNIT}px`;
-          div.style.top = `${(dy + offsetY) * this.UNIT}px`;
+          div.style.left = `${(dx + offsetX) * boxUnit}px`;
+          div.style.top = `${(dy + offsetY) * boxUnit}px`;
           this.nextBox.appendChild(div);
         }
       });
@@ -1178,6 +1182,24 @@ class TetrisGame {
     this.render();
   }
 
+  updateGarbageMeter() {
+    const meter = this.els.garbageMeter;
+    if (!meter) return;
+    meter.replaceChildren();
+    meter.setAttribute('aria-label', `${this.playerName}: ${this.garbageQueue} pending garbage lines`);
+    for (let index = 0; index < this.garbageQueue; index++) {
+      const line = document.createElement('div');
+      line.className = 'garbage-meter-line';
+      meter.appendChild(line);
+    }
+  }
+
+  enqueueGarbage(lines) {
+    if (!Number.isInteger(lines) || lines <= 0) return;
+    this.garbageQueue += lines;
+    this.updateGarbageMeter();
+  }
+
   lockPiece() {
     if (this.isAnimating || this.isGameOverAnimating) return;
     if (!this.current || !this.current.matrix) {
@@ -1240,6 +1262,7 @@ class TetrisGame {
         const rawAttack = ATTACK_TABLE[Math.min(linesCleared, 4)];
         const cancelled = Math.min(rawAttack, this.garbageQueue);
         this.garbageQueue -= cancelled;
+        this.updateGarbageMeter();
         const outgoing = rawAttack - cancelled;
         if (outgoing > 0) this.onAttack?.(outgoing);
 
@@ -1251,8 +1274,11 @@ class TetrisGame {
       }, 400);
     } else {
       if (this.garbageQueue > 0) {
-        this.applyGarbage(this.garbageQueue);
+        const pendingGarbage = this.garbageQueue;
         this.garbageQueue = 0;
+        this.updateGarbageMeter();
+        this.current = null;
+        this.applyGarbage(pendingGarbage);
         if (this.gameOver) return;
       }
       this.finishTurn(0);
@@ -1350,6 +1376,10 @@ class TetrisGame {
   }
 
   showGameOverScreen() {
+    if (this.onDefeat) {
+      this.els.gameOver?.style.setProperty('display', 'none');
+      return;
+    }
     this.els.gameMessage?.style.setProperty('display', 'block');
     const el = this.els.gameOver;
     if (!el) return;
@@ -1400,6 +1430,7 @@ class TetrisGame {
     this.botActionTimer = 0;
     this.botMode = null;
     this.garbageQueue = 0;
+    this.updateGarbageMeter();
     this.stopTimer();
     this.updateTimerDisplay();
     if (this.els.score) this.els.score.textContent = this.score;

--- a/versus.js
+++ b/versus.js
@@ -1,5 +1,3 @@
-const ATTACK_TABLE = [0, 0, 1, 2, 4];
-
 class VersusController {
   constructor() {
     const humanRoot = document.querySelector('.human-side');
@@ -40,7 +38,7 @@ class VersusController {
 
   route(target, lines) {
     if (!(target instanceof TetrisGame) || !Number.isInteger(lines) || lines <= 0 || this.finished) return;
-    target.garbageQueue += lines;
+    target.enqueueGarbage(lines);
   }
 
   togglePause() {
@@ -53,6 +51,7 @@ class VersusController {
   reset() {
     this.finished = false;
     this.overlay.hidden = true;
+    this.human.setIAAssist(false);
     this.human.reset();
     this.cpu.reset();
     this.cpu.setIAAssist(true);


### PR DESCRIPTION
## What changed
- decouple next-piece positioning from each board's dynamic `UNIT`
- make IA-Assist a true takeover mode by blocking manual piece controls while enabled
- move `ATTACK_TABLE` into the Tetris engine and use the aggressive `[0, 1, 2, 4, 6]` mapping
- add per-instance pending-garbage meters and keep them synchronized on route, cancellation, application and reset
- suppress the single-instance game-over panel when a versus defeat callback exists
- clear the locked piece before garbage rendering and reset human IA-Assist to manual for every new match

## Why
The previous implementation was mechanically correct, but the preview inherited the wrong CSS scale, the existing bot mostly cleared singles and therefore almost never attacked, manual input could invalidate an active bot plan, and pending garbage/cancellation had no visible representation.

## Validation
- `node --check tetris.js`
- `node --check versus.js`
- custom validator: 28 contracts passed
- isolated garbage-engine tests passed
- browser runtime: preview blocks remain inside the 72x60 box
- browser runtime: CPU cleared 2 lines and produced 2 visible pending garbage segments
- browser runtime: pending meter returned to 0 when garbage entered; 44 garbage blocks rendered
- browser runtime: New Game removed human IA-Assist active state and restored `MODO: MANUAL`
- no browser console warnings or errors