### PR TITLE
Align versus layout and piece previews

### DIFF
--- a/tetris.css
+++ b/tetris.css
@@ -372,6 +372,7 @@ button:active {
     display: flex;
     align-items: center;
     justify-content: center;
+    overflow: hidden;
 }
 
 /* Logs */
@@ -771,6 +772,7 @@ button:active {
 
 .main-grid {
     grid-template-columns: 1fr 300px 1fr;
+    grid-template-areas: "cpu controls human";
     gap: 12px;
     height: calc(100vh - 16px);
     align-items: stretch;
@@ -887,6 +889,18 @@ button:active {
 .compact-info .log-content {
     height: 60px;
     min-width: 0;
+}
+
+.cpu-side {
+    grid-area: cpu;
+}
+
+.shared-panel {
+    grid-area: controls;
+}
+
+.human-side {
+    grid-area: human;
 }
 
 @media (max-width: 1100px) {

--- a/tetris.js
+++ b/tetris.js
@@ -596,7 +596,10 @@ class TetrisGame {
     const h = matrix.length;
     const COLS_BOX = 6;
     const ROWS_BOX = 5;
-    const boxUnit = this.nextBox.clientWidth / COLS_BOX;
+    const boxUnit = Math.min(
+      this.nextBox.clientWidth / COLS_BOX,
+      this.nextBox.clientHeight / ROWS_BOX
+    );
     const offsetX = (COLS_BOX - w) / 2;
     const offsetY = (ROWS_BOX - h) / 2;
     matrix.forEach((row, dy) => {
@@ -604,6 +607,7 @@ class TetrisGame {
         if (val) {
           const div = document.createElement('div');
           div.className = BLOCK_CLASSES[this.next.typeId];
+          div.style.setProperty('--unit', `${boxUnit}px`);
           div.style.left = `${(dx + offsetX) * boxUnit}px`;
           div.style.top = `${(dy + offsetY) * boxUnit}px`;
           this.nextBox.appendChild(div);

--- a/versus.js
+++ b/versus.js
@@ -106,7 +106,7 @@ class VersusController {
 
   bindScale() {
     const syncVersusBoards = () => {
-      syncBoardScale(this.cpu, 0.7);
+      syncBoardScale(this.cpu);
       syncBoardScale(this.human);
     };
     requestAnimationFrame(syncVersusBoards);


### PR DESCRIPTION
## What changed
- explicitly pin CPU / controls / human to left / center / right grid areas
- render CPU and human boards with the same scale
- calculate preview units from both available width and height
- apply the calculated unit directly to preview block dimensions and sprite scaling
- clip preview boxes as a final containment guard

## Validation
- syntax and custom validator: 29 contracts passed
- garbage-engine regression tests passed
- browser runtime: human is to the right of CPU
- browser runtime: both boards are 336x616 with `UNIT=28`
- browser runtime: preview and active blocks use the same sprite, outline and proportional sprite sizing
- 40 preview boxes checked across 20 resets with zero overflow
- no browser console warnings or errors